### PR TITLE
Fix aria inheritance bug for inherited element types

### DIFF
--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -54,13 +54,36 @@ function Modal({title, type, elements, theme = "Singularity", animation = "fade"
           const elementDef = elementsData.find(e => e.element === field.type) || elementsData.find(e => e["inherited-element"]?.includes(field.type));
           const Tag = elementDef.is_custom? componentsMap[elementDef.tag] : elementDef.tag;
 
+          // Safely get base aria props with defensive check for undefined/null
+          let ariaProps = elementDef.aria ? { ...elementDef.aria } : {};
+          
+          // Apply inherit-overrides if the element type has specific overrides
+          // Safe navigation to prevent errors if nested properties are missing
+          const overrideConfig = elementDef["inherit-overrides"]?.[field.type];
+          if (overrideConfig && overrideConfig.aria) {
+            ariaProps = { ...ariaProps, ...overrideConfig.aria };
+          }
+
           return(
             <div className="grouped-elements" key={field.id || i} >
               {Array.from({ length: field.amount }, (_, j) => {
                   const name = field.name[j]
+                  
+                  // Build aria props object - only include defined values to avoid passing undefined attributes
+                  const ariaAttributes = {};
+                  if (ariaProps.role !== undefined && ariaProps.role !== null) {
+                    ariaAttributes.role = ariaProps.role;
+                  }
+                  if (ariaProps["aria-label"] !== undefined && ariaProps["aria-label"] !== null) {
+                    ariaAttributes["aria-label"] = ariaProps["aria-label"];
+                  }
+                  if (ariaProps["aria-required"] === true || ariaProps["aria-required"] === false) {
+                    ariaAttributes["aria-required"] = ariaProps["aria-required"];
+                  }
+
                   const Tagprobs = {
                     className: elementDef["default-class"],
-                    role: elementDef.aria.role,
+                    ...ariaAttributes,
                     name: name,                    
                     ...(elementDef["supports-placeholder"] && ({placeholder: field.placeholder[j]})),
                     ...(elementDef["supports_type"] && ({type: field.type})),


### PR DESCRIPTION
## Summary

Fixes unsafe access to `aria` properties when rendering form elements in modals, preventing potential runtime errors when configuration data is incomplete or missing.

## Problem

The previous implementation directly accessed `elementDef.aria.role` without defensive checks:

```jsx
role: elementDef.aria.role  // ❌ Could throw if aria is undefined/null
```

This caused issues when:
- Element definitions don't include an `aria` property
- The `aria` object exists but lacks specific properties like `role`, `aria-label`, or `aria-required`
- Configuration data is partially loaded or malformed

## Solution

Added defensive checks at multiple levels:

1. **Safe base aria props extraction** - Handles missing/null `elementDef.aria`:
   ```jsx
   let ariaProps = elementDef.aria ? { ...elementDef.aria } : {};
   ```

2. **Override handling with safe navigation** - Prevents errors when `inherit-overrides` is undefined:
   ```jsx
   const overrideConfig = elementDef["inherit-overrides"]?.[field.type];
   if (overrideConfig && overrideConfig.aria) { ... }
   ```

3. **Conditional attribute passing** - Only includes defined aria attributes in the final props object:
   ```jsx
   const ariaAttributes = {};
   if (ariaProps.role !== undefined && ariaProps.role !== null) {
     ariaAttributes.role = ariaProps.role;
   }
   // ... similar checks for aria-label and aria-required
   ```

## Verification

- ✅ Renders without errors when `elementDef.aria` is missing
- ✅ Handles partial aria configurations (e.g., has `role` but no `aria-label`)
- ✅ Correctly applies inherit-overrides when present
- ✅ No undefined attributes passed to rendered components

## Limitations

This fix only addresses the three most common aria properties (`role`, `aria-label`, `aria-required`). If additional aria attributes are added in the future, they'll need similar defensive checks. A more generic solution could iterate over all defined keys in `ariaProps` instead of hard-checking each one.