### PR TITLE
Fix aria inheritance bug for inherited element types

### DIFF
--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -58,10 +58,32 @@ function Modal({title, type, elements, theme = "Singularity", animation = "fade"
             <div className="grouped-elements" key={field.id || i} >
               {Array.from({ length: field.amount }, (_, j) => {
                   const name = field.name[j]
+                  
+                  // Spread aria props safely to avoid runtime errors if elementDef.aria is missing or null
+                  let ariaProps = elementDef.aria ? { ...elementDef.aria } : {};
+                  
+                  // Allow field-specific aria overrides for inherited elements (e.g., search gets role="searchbox")
+                  const overrideConfig = elementDef["inherit-overrides"]?.[field.type];
+                  if (overrideConfig && overrideConfig.aria) {
+                    ariaProps = { ...ariaProps, ...overrideConfig.aria };
+                  }
+                  
+                  // Build aria attributes object with defensive checks for undefined/null values
+                  const ariaAttributes = {};
+                  if (ariaProps.role !== undefined && ariaProps.role !== null) {
+                    ariaAttributes.role = ariaProps.role;
+                  }
+                  if (ariaProps["aria-label"] !== undefined && ariaProps["aria-label"] !== null) {
+                    ariaAttributes["aria-label"] = ariaProps["aria-label"];
+                  }
+                  if (ariaProps["aria-required"] !== undefined && ariaProps["aria-required"] !== null) {
+                    ariaAttributes["aria-required"] = ariaProps["aria-required"];
+                  }
+
                   const Tagprobs = {
                     className: elementDef["default-class"],
-                    role: elementDef.aria.role,
                     name: name,                    
+                    ...ariaAttributes,
                     ...(elementDef["supports-placeholder"] && ({placeholder: field.placeholder[j]})),
                     ...(elementDef["supports_type"] && ({type: field.type})),
                     ...(elementDef["supports_autocomplete"] && ({autoComplete: field.type === "password" ? "current-password": "on"}))


### PR DESCRIPTION
## Summary

Fixes runtime errors when rendering modal form elements with missing or undefined ARIA attributes. The previous implementation directly accessed `elementDef.aria.role` without defensive checks, causing crashes when aria properties were null/undefined.

## Problem

When the modal component rendered form fields, it assumed `elementDef.aria` always existed and contained valid values:

```jsx
// Before - unsafe direct access
role: elementDef.aria.role  // ❌ Crashes if elementDef.aria is missing/null
```

This caused runtime errors in scenarios where:
- ARIA configuration was omitted from the element definition
- Individual aria properties were undefined or null
- Field-specific overrides weren't properly merged with defaults

## Solution

Implemented defensive ARIA attribute handling with three key improvements:

### 1. Safe Default Handling
```jsx
let ariaProps = elementDef.aria ? { ...elementDef.aria } : {};
```
Gracefully handles missing `elementDef.aria` by defaulting to empty object instead of crashing.

### 2. Field-Specific Overrides
```jsx
const overrideConfig = elementDef["inherit-overrides"]?.[field.type];
if (overrideConfig && overrideConfig.aria) {
  ariaProps = { ...ariaProps, ...overrideConfig.aria };
}
```
Allows field types to override inherited ARIA attributes (e.g., search fields get `role="searchbox"`).

### 3. Explicit Null/Undefined Checks
```jsx
const ariaAttributes = {};
if (ariaProps.role !== undefined && ariaProps.role !== null) {
  ariaAttributes.role = ariaProps.role;
}
// ... same for aria-label, aria-required
```
Only spreads ARIA attributes that have valid values, preventing React warnings about invalid props.

## Verification

- ✅ Tested with `elementDef.aria` missing entirely (no crash)
- ✅ Tested with individual properties set to `null`/`undefined` (attributes omitted cleanly)
- ✅ Verified field-specific overrides merge correctly with defaults
- ✅ Confirmed no React console warnings about invalid ARIA props

## Limitations

This fix only handles three specific ARIA attributes (`role`, `aria-label`, `aria-required`). If additional ARIA properties are needed in the future, they should be added to the defensive check block. The current implementation prioritizes safety over extensibility for these core accessibility attributes.

## Addition

Fixes #11  