### PR TITLE
feat: add keyboard navigation and Enter selection to DynamicSelect

### DIFF
--- a/src/components/select/SelectCompiler.jsx
+++ b/src/components/select/SelectCompiler.jsx
@@ -23,7 +23,8 @@ function DynamicSelect({
     is_rendered: true,
     is_open: false,
     elements: [],
-    selected: ''
+    selected: '',
+    activeIndex: -1
   });
   const selectRef = React.useRef(null);
   const dropdownSelectRef = React.useRef(null);
@@ -87,6 +88,48 @@ function DynamicSelect({
     (e) => e.animation.trim().toLowerCase() === animation.trim().toLowerCase()
   );
 
+  function HandleKey(e, controller){
+    if(Select.is_open == false) return 
+
+    const {key} = e;
+    const max = Select.elements.length -1;
+    const min = -1;
+    const index = Select.activeIndex
+
+
+    if(key === "ArrowUp"){
+      if(index <= min) return
+      controller((prevData)=> ({
+        ...prevData,
+        activeIndex: index -1
+      }))
+      e.preventDefault()
+    }
+
+    if(key === "ArrowDown"){
+      if(index >= max) return
+      controller((prevData)=> ({
+        ...prevData,
+        activeIndex: index +1
+      }))
+      e.preventDefault()
+    }
+
+
+    if(key === 'Enter'){
+      if(index < 0 || index > max) return
+      
+      selectRef.current.value = Select.elements[index]
+      controller((prevData)=> ({
+        ...prevData,
+        selected: Select.elements[index],
+        is_open: false,
+        activeIndex: -1
+      }))
+      e.preventDefault()
+    }
+  }
+
   useGSAP(() => {
     if (!selectRef.current || !currentAnimation) return;
 
@@ -119,12 +162,14 @@ function DynamicSelect({
         onBlur={(e) => {
           TranslateEngineType(e.target.value, 'blur', SetSelect);
         }}
+        onKeyDown={(e) => HandleKey(e, SetSelect)}
       />
       <SelectEngine
         elements={Select.elements}
         is_open={Select.is_open}
         is_rendered={Select.is_rendered}
         inputRef={selectRef}
+        activeIndex={Select.activeIndex}
         ref={dropdownSelectRef}
         controller={SetSelect}
         OnChangeCallback={(value) => onChangeInternalCallback(value)}

--- a/src/components/select/SelectEngine.jsx
+++ b/src/components/select/SelectEngine.jsx
@@ -12,6 +12,7 @@ const SelectEngine = forwardRef(
       selectedElement = '',
       placeholder = 'Select...',
       controller,
+      activeIndex,
       inputRef,
       OnChangeCallback,
       type
@@ -28,7 +29,8 @@ const SelectEngine = forwardRef(
       inputRef.current.value = value;
       controller((prevData) => ({
         ...prevData,
-        is_open: false
+        is_open: false,
+        activeIndex: -1
       }));
 
       OnChangeCallback(value);
@@ -72,6 +74,13 @@ const SelectEngine = forwardRef(
       return () => observer.disconnect();
     }, []);
 
+    useEffect(() => {
+      if(activeIndex >= 0 && itemsRef.current[activeIndex]){
+        itemsRef.current[activeIndex].scrollIntoView({block: 'nearest'})
+      }
+    },[activeIndex])
+
+
     return (
       <>
         {is_rendered && (
@@ -91,9 +100,16 @@ const SelectEngine = forwardRef(
                   role="option"
                   ref={(ele) => (itemsRef.current[index] = ele)}
                   key={index}
+                  style={index === activeIndex ? {backgroundColor: '#e0f7fa', cursor: 'pointer'}: {}}
                   onMouseDown={(e) => {
                     e.preventDefault();
                     ChangeValue(element);
+                  }}
+                  onMouseEnter={() => {
+                    controller((prevData) => ({
+                      ...prevData,
+                      activeIndex: index
+                    }));
                   }}
                 >
                   {element}

--- a/src/components/select/dependencies/style/styles.css
+++ b/src/components/select/dependencies/style/styles.css
@@ -53,11 +53,6 @@
   letter-spacing: 0.5px;
   margin-left: 0.4rem;
 }
-.dyvix-dropdown-select li:hover {
-  transform: scale(1.003);
-  background-color: #e0f7fa;
-  cursor: pointer;
-}
 .dyvix-dropdown-select li:active {
   background-color: #b2ebf2;
   color: white;


### PR DESCRIPTION
## What
Add keyboard navigation to `DynamicSelect` and `SelectEngine` components.

## Changes
- `SelectCompiler.jsx` — added `activeIndex` state, `onKeyDown` handler, ArrowUp/ArrowDown/Enter support
- `SelectEngine.jsx` — added active item highlight, scroll into view, mouse/keyboard sync
- `styles.css` — removed `li:hover` CSS in favour of controlled highlight via `activeIndex`

Closes #48