### PR TITLE
fix: resolve #100 — [Feature] Add `Warning` and `info` toast types.

### DIFF
--- a/src/components/toast/bus.jsx
+++ b/src/components/toast/bus.jsx
@@ -2,7 +2,9 @@ const listeners = [];
 
 const dyvixToast = {
   success: (message) => emit({ message: message, type: 'Success' }),
-  error: (message) => emit({ message: message, type: 'Error' })
+  error: (message) => emit({ message: message, type: 'Error' }),
+  warning: (message) => emit({ message: message, type: 'Warning' }),
+  info: (message) => emit({ message: message, type: 'Info' })
 };
 
 function emit(toast) {

--- a/src/components/toast/dependencies/style/style.css
+++ b/src/components/toast/dependencies/style/style.css
@@ -30,6 +30,16 @@
   background-color: #a8fcb4;
   border: 1px solid rgba(20, 206, 79, 0.3);
 }
+
+.dyvix-toast-warning {
+  background-color: #fff3cd;
+  border: 1px solid rgba(255, 193, 7, 0.3);
+}
+
+.dyvix-toast-info {
+  background-color: #d1ecf1;
+  border: 1px solid rgba(23, 162, 184, 0.3);
+}
 .dyvix-toast-title {
   width: 100%;
   font-weight: 600;
@@ -62,6 +72,14 @@
 .toast-success {
   color: #1df13c;
 }
+
+.toast-warning {
+  color: #ffc107;
+}
+
+.toast-info {
+  color: #17a2b8;
+}
 .toast-error .dyvix-toast-icon {
   border-color: #ff3366;
   box-shadow: inset 0 0 4px rgba(5, 2, 3, 0.848);
@@ -69,6 +87,16 @@
 .toast-success .dyvix-toast-icon {
   border-color: #14ce4f;
   box-shadow: inset 0 0 4px rgba(2, 5, 3, 0.848);
+}
+
+.toast-warning .dyvix-toast-icon {
+  border-color: #ffc107;
+  box-shadow: inset 0 0 4px rgba(5, 3, 2, 0.848);
+}
+
+.toast-info .dyvix-toast-icon {
+  border-color: #17a2b8;
+  box-shadow: inset 0 0 4px rgba(2, 3, 5, 0.848);
 }
 /* move to positions.css ? */
 .dyvix-top-right {

--- a/src/components/toast/dependencies/types.json
+++ b/src/components/toast/dependencies/types.json
@@ -6,5 +6,13 @@
   {
     "type": "Success",
     "class": "dyvix-toast-success"
+  },
+  {
+    "type": "Warning",
+    "class": "dyvix-toast-warning"
+  },
+  {
+    "type": "Info",
+    "class": "dyvix-toast-info"
   }
 ]


### PR DESCRIPTION
## Summary

fix: resolve #100 — [Feature] Add `Warning` and `info` toast types.

## Problem

**Severity**: `Medium` | **File**: `src/components/toast/bus.jsx`

The toast bus needs to be updated to recognize and handle 'warning' and 'info' toast types in addition to the existing 'error' and 'success' types. This will involve updating the type validation and possibly the toast creation logic.

## Solution

Add 'warning' and 'info' to the allowed toast types array or enum, and ensure the toast creation function can handle these new types properly.

## Changes

- `src/components/toast/bus.jsx` (modified)
- `src/components/toast/dependencies/style/style.css` (modified)
- `src/components/toast/dependencies/types.json` (modified)

## Testing

- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced