### PR TITLE
fix: resolve #96 — [Chore] Move toast position styles into there own positions.css

### DIFF
--- a/src/components/toast/dependencies/style/positions.css
+++ b/src/components/toast/dependencies/style/positions.css
@@ -1,0 +1,25 @@
+.dyvix-top-left {
+  top: 20px;
+  left: 20px;
+}
+
+.dyvix-top-right {
+  top: 20px;
+  right: 20px;
+}
+
+.dyvix-bottom-left {
+  bottom: 20px;
+  left: 20px;
+}
+
+.dyvix-bottom-right {
+  bottom: 20px;
+  right: 20px;
+}
+
+.dyvix-top-center {
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+}

--- a/src/components/toast/dependencies/style/style.css
+++ b/src/components/toast/dependencies/style/style.css
@@ -70,30 +70,4 @@
   border-color: #14ce4f;
   box-shadow: inset 0 0 4px rgba(2, 5, 3, 0.848);
 }
-/* move to positions.css ? */
-.dyvix-top-right {
-  top: 1rem;
-  right: 1rem;
-}
-.dyvix-top-left {
-  top: 1rem;
-  left: 1rem;
-}
-.dyvix-bottom-right {
-  bottom: 1rem;
-  right: 1rem;
-}
-.dyvix-bottom-left {
-  bottom: 1rem;
-  left: 1rem;
-}
-.dyvix-top-center {
-  top: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-}
-.dyvix-bottom-center {
-  bottom: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-}
+

--- a/src/components/toast/toastContainer.jsx
+++ b/src/components/toast/toastContainer.jsx
@@ -1,4 +1,5 @@
 import './dependencies/style/style.css';
+import './dependencies/style/positions.css';
 import positionData from './dependencies/positions.json';
 import TypesData from './dependencies/types.json';
 import animationsData from '../animations.json';


### PR DESCRIPTION
## Summary

fix: resolve #96 — [Chore] Move toast position styles into there own positions.css

## Problem

**Severity**: `Low` | **File**: `src/components/toast/dependencies/style/positions.css`

Create a new CSS file to house all toast position-related styles that are currently in the main style.css file. This will improve code organization and maintainability by separating concerns.

## Solution

Create a new file with the toast position classes: .dyvix-top-left, .dyvix-top-right, .dyvix-bottom-left, .dyvix-bottom-right, and .dyvix-top-center. These styles will be moved from the existing style.css file.

## Changes

- `src/components/toast/dependencies/style/positions.css` (new)
- `src/components/toast/dependencies/style/style.css` (modified)
- `src/components/toast/toastContainer.jsx` (modified)

## Testing

- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced