### PR TITLE
fix: resolve #16 — Add `textarea` modal element support.

### DIFF
--- a/src/components/modal/InputValidation.jsx
+++ b/src/components/modal/InputValidation.jsx
@@ -46,7 +46,8 @@ const supportedTypes = [
   'search',
   'url',
   'tel',
-  'checkbox'
+  'checkbox',
+  'textarea'
 ];
 let config = null;
 

--- a/src/components/modal/dependencies/elements.json
+++ b/src/components/modal/dependencies/elements.json
@@ -25,6 +25,21 @@
     "r-variant": true
   },
   {
+    "element": "textarea",
+    "tag": "textarea",
+    "default-class": "modal-textarea",
+    "aria": {
+      "role": "textbox",
+      "aria-label": ""
+    },
+    "supports-placeholder": true,
+    "supports_type": false,
+    "supports_autocomplete": true,
+    "is_custom": false,
+    "requires-options": false,
+    "r-variant": true
+  },
+  {
     "element": "select",
     "tag": "select",
     "default-class": "modal-select",

--- a/src/components/modal/dependencies/style/elements.css
+++ b/src/components/modal/dependencies/style/elements.css
@@ -181,3 +181,7 @@
   gap: 0.5rem;
   cursor: pointer;
 }
+.modal-textarea {
+  max-height: 70px;
+  resize: vertical;
+}

--- a/src/components/modal/dependencies/style/elements.css
+++ b/src/components/modal/dependencies/style/elements.css
@@ -183,5 +183,6 @@
 }
 .modal-textarea {
   max-height: 70px;
+  min-height: 35px;
   resize: vertical;
 }


### PR DESCRIPTION
## Summary

fix: resolve #16 — Add `textarea` modal element support.

## Problem

**Severity**: `Medium` | **File**: `src/components/modal/dependencies/elements.json`

Add a textarea entry to the elements configuration file so that the modal can render textarea inputs with proper styling and attributes.

## Solution

Add a new entry for "textarea" in the JSON file with appropriate properties like type, className, attributes, etc. Follow the same pattern as other input elements.

## Changes

- `src/components/modal/dependencies/elements.json` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced