### PR TITLE
Add input component playground

### DIFF
--- a/docs/.vitepress/theme/components/input/InputPlayground.jsx
+++ b/docs/.vitepress/theme/components/input/InputPlayground.jsx
@@ -60,13 +60,13 @@ export default function InputPlayground() {
     {
       utility: 'background',
       type: 'color',
-      current: '#ffffff',
+      current: '#32374e',
       format: 'string'
     },
     {
       utility: 'color',
       type: 'color',
-      current: '#111827',
+      current: undefined,
       format: 'string'
     }
   ]);

--- a/docs/.vitepress/theme/components/input/InputPlayground.jsx
+++ b/docs/.vitepress/theme/components/input/InputPlayground.jsx
@@ -1,0 +1,108 @@
+import { DyvixInput } from 'dyvix-ui';
+import Wrapper from '../Wrapper';
+import React from 'react';
+import { DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+
+export default function InputPlayground() {
+  const [config, setConfig] = React.useState([
+    {
+      utility: 'type',
+      type: 'select',
+      options: {
+        TEXT: 'text',
+        EMAIL: 'email',
+        PASSWORD: 'password',
+        NUMBER: 'number',
+        SEARCH: 'search',
+        TEL: 'tel',
+        URL: 'url'
+      },
+      current: 'text',
+      format: 'string'
+    },
+    {
+      utility: 'animation',
+      type: 'select',
+      options: DYVIX_GLOBAL_ANIMATION,
+      current: DYVIX_GLOBAL_ANIMATION.AURORA,
+      format: 'string'
+    },
+    {
+      utility: 'placeholder',
+      type: 'text',
+      current: 'Enter your name',
+      format: 'string'
+    },
+    {
+      utility: 'name',
+      type: 'text',
+      current: 'fullName',
+      format: 'string'
+    },
+    {
+      utility: 'id',
+      type: 'text',
+      current: 'dyvix-input-demo',
+      format: 'string'
+    },
+    {
+      utility: 'aria-label',
+      type: 'text',
+      current: 'Demo input',
+      format: 'string'
+    },
+    {
+      utility: 'autoComplete',
+      type: 'text',
+      current: 'name',
+      format: 'string'
+    },
+    {
+      utility: 'background',
+      type: 'color',
+      current: '#ffffff',
+      format: 'string'
+    },
+    {
+      utility: 'color',
+      type: 'color',
+      current: '#111827',
+      format: 'string'
+    }
+  ]);
+
+  const type = config.find((e) => e.utility === 'type').current;
+  const animation = config.find((e) => e.utility === 'animation').current;
+  const placeholder = config.find((e) => e.utility === 'placeholder').current;
+  const name = config.find((e) => e.utility === 'name').current;
+  const id = config.find((e) => e.utility === 'id').current;
+  const ariaLabel = config.find((e) => e.utility === 'aria-label').current;
+  const autoComplete = config.find((e) => e.utility === 'autoComplete').current;
+  const background = config.find((e) => e.utility === 'background').current;
+  const color = config.find((e) => e.utility === 'color').current;
+
+  const props = {
+    ...(type && { type }),
+    ...(animation && { animation }),
+    ...(placeholder && { placeholder }),
+    ...(name && { name }),
+    ...(id && { id }),
+    ...(ariaLabel && { 'aria-label': ariaLabel }),
+    ...(autoComplete && { autoComplete }),
+    ...(background && { background }),
+    ...(color && { color })
+  };
+
+  return (
+    <Wrapper
+      componentConfig={config}
+      componentCallback={setConfig}
+      tag={'DyvixInput'}
+    >
+      <DyvixInput
+        {...props}
+        onChange={(event) => console.log(event.target.value)}
+      />
+    </Wrapper>
+  );
+}

--- a/docs/.vitepress/theme/components/input/InputPlayground.vue
+++ b/docs/.vitepress/theme/components/input/InputPlayground.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import InputPlayground from './InputPlayground';
+
+const container = ref(null);
+
+onMounted(() => {
+  ReactDOM.createRoot(container.value).render(
+    React.createElement(InputPlayground)
+  );
+});
+</script>
+
+<template>
+  <div ref="container"></div>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import DefaultTheme from 'vitepress/theme';
 import ButtonPlayground from './components/button/ButtonPlayground.vue';
+import InputPlayground from './components/input/InputPlayground.vue';
 import ModalPlayground from './components/modal/ModalPlayground.vue';
 import './custom.css';
 
@@ -7,6 +8,7 @@ export default {
   ...DefaultTheme,
   enhanceApp({ app }) {
     app.component('ButtonPlayground', ButtonPlayground);
+    app.component('InputPlayground', InputPlayground);
     app.component('ModalPlayground', ModalPlayground);
   }
 };

--- a/docs/components/input/input.md
+++ b/docs/components/input/input.md
@@ -37,7 +37,7 @@ A config-driven animated input component with support for default coloring style
 - `onChange`
   - : `function`. A callback function triggered upon input value change.
 
-## Playground
+## Try it
 
 <InputPlayground />
 

--- a/docs/components/input/input.md
+++ b/docs/components/input/input.md
@@ -37,6 +37,10 @@ A config-driven animated input component with support for default coloring style
 - `onChange`
   - : `function`. A callback function triggered upon input value change.
 
+## Playground
+
+<InputPlayground />
+
 ## Example
 
 ```jsx


### PR DESCRIPTION
Closes #170

## Changes
- Add a React-powered `InputPlayground` with configurable type, animation, placeholder, name, id, aria label, autocomplete, background, and text color controls.
- Register the playground in the VitePress theme.
- Embed the playground on the Dyvix Input documentation page.

## Testing
- `npm run docs:build`
