### PR TITLE
Add DynamicSelect playground to docs

### DIFF
--- a/docs/.vitepress/theme/components/select/SelectPlayground.jsx
+++ b/docs/.vitepress/theme/components/select/SelectPlayground.jsx
@@ -1,0 +1,56 @@
+import { DynamicSelect } from 'dyvix-ui';
+import Wrapper from '../Wrapper';
+import React from 'react';
+import { DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+
+export default function SelectPlayground() {
+  const [config, setConfig] = React.useState([
+    {
+      utility: 'type',
+      type: 'select',
+      options: {
+        SELECT: 'select',
+        AUTOCOMPLETE: 'autocomplete'
+      },
+      current: 'select',
+      format: 'string'
+    },
+    {
+      utility: 'animation',
+      type: 'select',
+      options: DYVIX_GLOBAL_ANIMATION,
+      current: DYVIX_GLOBAL_ANIMATION.FADE,
+      format: 'string'
+    },
+    {
+      utility: 'placeholder',
+      type: 'text',
+      current: 'Select an option',
+      format: 'string'
+    }
+  ]);
+
+  const type = config.find((e) => e.utility === 'type').current;
+  const animation = config.find((e) => e.utility === 'animation').current;
+  const placeholder = config.find((e) => e.utility === 'placeholder').current;
+  const props = {
+    ...(type && { type }),
+    ...(animation && { animation }),
+    ...(placeholder && { placeholder })
+  };
+  return (
+    <Wrapper
+      componentConfig={config}
+      componentCallback={setConfig}
+      tag={'DynamicSelect'}
+    >
+      <DynamicSelect
+       className="ex-select"
+       type="select"
+       elements={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+       onChange={(data) => console.log(data)}
+        {...props}
+      />
+   </Wrapper>
+);
+}

--- a/docs/.vitepress/theme/components/select/SelectPlayground.vue
+++ b/docs/.vitepress/theme/components/select/SelectPlayground.vue
@@ -1,0 +1,17 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import SelectPlayground from './SelectPlayground';
+
+const container = ref(null);
+onMounted(() => {
+  ReactDOM.createRoot(container.value).render(
+    React.createElement(SelectPlayground)
+  );
+});
+</script>
+
+<template>
+  <div ref="container"></div>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import DefaultTheme from 'vitepress/theme';
 import ButtonPlayground from './components/button/ButtonPlayground.vue';
+import SelectPlayground from './components/select/SelectPlayground.vue';
 import InputPlayground from './components/input/InputPlayground.vue';
 import ModalPlayground from './components/modal/ModalPlayground.vue';
 import './custom.css';
@@ -10,5 +11,6 @@ export default {
     app.component('ButtonPlayground', ButtonPlayground);
     app.component('InputPlayground', InputPlayground);
     app.component('ModalPlayground', ModalPlayground);
+    app.component('SelectPlayground', SelectPlayground);
   }
 };

--- a/docs/components/select/select.md
+++ b/docs/components/select/select.md
@@ -49,3 +49,6 @@ function SelectExample() {
   );
 }
 ```
+## Try it
+
+<SelectPlayground />


### PR DESCRIPTION
Adds an interactive DynamicSelect playground to the Select docs page.

The playground follows the existing Button playground pattern and includes controls for type, animation, and placeholder. It also uses a static elements array, as discussed in the issue.