### PR TITLE
Add DyvixFile playground

### DIFF
--- a/docs/.vitepress/theme/components/file/FilePlayground.jsx
+++ b/docs/.vitepress/theme/components/file/FilePlayground.jsx
@@ -1,0 +1,87 @@
+import { DyvixFile } from 'dyvix-ui';
+import Wrapper from '../Wrapper';
+import React from 'react';
+import { DYVIX_GLOBAL_THEME, DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+
+export default function FilePlayground() {
+  const [config, setConfig] = React.useState([
+    {
+      utility: 'label',
+      type: 'text',
+      current: 'Upload File',
+      format: 'string'    
+    },
+    {
+      utility: 'animation',
+      type: 'select',
+      options: DYVIX_GLOBAL_ANIMATION,
+      current: DYVIX_GLOBAL_ANIMATION.AURORA,
+      format: 'string'
+    },
+    {
+      utility: 'theme',
+      type: 'select',
+      options: DYVIX_GLOBAL_THEME,
+      current: DYVIX_GLOBAL_THEME.MIDNIGHT,
+      format: 'string'
+    },
+    {
+      utility: 'background',
+      type: 'color',
+      current: undefined,
+      format: 'string'
+    },
+    {
+      utility: 'color',
+      type: 'color',
+      current: undefined,
+      format: 'string'
+    },
+    {
+      utility: 'multiple',
+      type: 'select',
+      options: {
+        TRUE: true,
+        FALSE: ''
+      },
+      current: true,
+      format: 'boolean'
+    },
+    {
+      utility: 'accept',
+      type: 'text',
+      current: '.jpg, .jpeg, .png',
+      format: 'string'
+    }
+  ]);
+
+  const label = config.find((e) => e.utility === 'label').current;
+  const animation = config.find((e) => e.utility === 'animation').current;
+  const theme = config.find((e) => e.utility === 'theme').current;
+  const background = config.find((e) => e.utility === 'background').current;
+  const color = config.find((e) => e.utility === 'color').current;
+  const multiple = config.find((e) => e.utility === 'multiple').current;
+  const accept = config.find((e) => e.utility === 'accept').current;
+
+  const props = {
+  ...(label && { label: label }),
+  ...(animation && { animation: animation }),
+  ...(theme && { theme: theme }),
+  ...(background && { background: background }),
+  ...(color && { color: color }),
+  ...(multiple && { multiple: multiple }),
+  ...(accept && { accept: accept })
+};
+  return (
+    <Wrapper
+      componentConfig={config}
+      componentCallback={setConfig}
+      tag={'DyvixFile'}
+    >
+      <DyvixFile
+        onUpload={(data) => console.log(data)}
+        {...props}
+      />
+    </Wrapper>
+  );
+}

--- a/docs/.vitepress/theme/components/file/FilePlayground.vue
+++ b/docs/.vitepress/theme/components/file/FilePlayground.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import FilePlayground from './FilePlayground';
+
+const container = ref(null);
+
+onMounted(() => {
+  ReactDOM.createRoot(container.value).render(
+    React.createElement(FilePlayground)
+  );
+});
+</script>
+
+<template>
+  <div ref="container"></div>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,14 +1,16 @@
 import DefaultTheme from 'vitepress/theme';
 import ButtonPlayground from './components/button/ButtonPlayground.vue';
-import SelectPlayground from './components/select/SelectPlayground.vue';
+import FilePlayground from './components/file/FilePlayground.vue';
 import InputPlayground from './components/input/InputPlayground.vue';
 import ModalPlayground from './components/modal/ModalPlayground.vue';
+import SelectPlayground from './components/select/SelectPlayground.vue';
 import './custom.css';
 
 export default {
   ...DefaultTheme,
   enhanceApp({ app }) {
     app.component('ButtonPlayground', ButtonPlayground);
+    app.component('FilePlayground', FilePlayground);
     app.component('InputPlayground', InputPlayground);
     app.component('ModalPlayground', ModalPlayground);
     app.component('SelectPlayground', SelectPlayground);

--- a/docs/components/file/file.md
+++ b/docs/components/file/file.md
@@ -51,3 +51,7 @@ function FileExample() {
   );
 }
 ```
+
+## Try it
+
+<FilePlayground />


### PR DESCRIPTION
## Summary

Adds an interactive playground for the DyvixFile component documentation.

## Changes

- Added `FilePlayground.jsx`
- Added `FilePlayground.vue`
- Registered `FilePlayground` in the VitePress theme
- Embedded the playground in `file.md`

## Testing

- Ran the documentation locally with `npm run docs:dev`
- Tested the File playground controls for label, theme, animation, background, color, multiple, and accept