### PR TITLE
docs: improve modal playground placeholders

### DIFF
--- a/docs/.vitepress/theme/components/modal/ModalPlayground.jsx
+++ b/docs/.vitepress/theme/components/modal/ModalPlayground.jsx
@@ -102,10 +102,10 @@ export default function ModalPlayground() {
           amount: 2
         },
         {
-          type: 'text',
-          placeholder: ['First Namex', 'Last Namex'],
-          id: 'names',
-          name: ['firstNamez', 'lastNamez'],
+          type: 'email',
+          placeholder: ['Email Address', 'Confirm Email'],
+          id: 'contactEmails',
+          name: ['email', 'confirmEmail'],
           className: 'ex-text2',
           amount: 2
         }


### PR DESCRIPTION
## Summary

Updates the modal playground's second input group so it uses realistic contact-email labels instead of the placeholder-like `First Namex` / `Last Namex` and `firstNamez` / `lastNamez` values called out in #190.

## Verification

- `npx prettier --check docs/.vitepress/theme/components/modal/ModalPlayground.jsx`
- `git diff --check`
- `npm run docs:build`

Closes #190
