### PR TITLE
feat: implement default animation injection for modal presets

### DIFF
--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -192,6 +192,11 @@ function Modal({
   };
   if (currentPreset) {
     title = title !== '!/' ? title : currentPreset['default-title'];
+
+    animation =
+      animation !== '!/'
+        ? animation
+        : currentPreset['default-animation'] || 'fade';
   }
   React.useEffect(() => {
     async function GetFields() {


### PR DESCRIPTION
## Changes

* Added preset default animation injection using `default-animation`
* Preserved user-provided animations without overriding them
* Added fallback to `fade` when preset animation is unavailable

close #63
