### PR TITLE
refactor: fix typo GaurdStatus -> GuardStatus

### DIFF
--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './dependencies/style/style.css';
-import { EvaluateFailure, GaurdStatus } from '../../utils/DyvixGuard';
+import { EvaluateFailure, GuardStatus } from '../../utils/DyvixGuard';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
 import { Validatebtn } from './validation';
@@ -49,7 +49,7 @@ function DyvixButton({
         instanceId
       );
 
-      if (validator.status === GaurdStatus.Error) {
+      if (validator.status === GuardStatus.Error) {
         return EvaluateFailure(validator.error, validator.status);
       }
     }

--- a/src/components/button/validation.jsx
+++ b/src/components/button/validation.jsx
@@ -1,6 +1,6 @@
 import {
   EvaluateFailure,
-  GaurdStatus,
+  GuardStatus,
   allowsNull
 } from '../../utils/DyvixGuard';
 import { ValidatAndLoadJSON } from '../../utils/Smart Json Caching/SJCManager';
@@ -42,16 +42,16 @@ export async function Validatebtn(animation, theme, callback, instance) {
   );
   if (!isAnimation.status && !allowsNull(normalizedAnimation)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid animation.'
     };
   }
   if (normalizedTheme !== '!/' && !isTheme.status) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid theme.'
     };
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }

--- a/src/components/file/file.jsx
+++ b/src/components/file/file.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './dependencies/style/style.css';
-import { EvaluateFailure, GaurdStatus } from '../../utils/DyvixGuard';
+import { EvaluateFailure, GuardStatus } from '../../utils/DyvixGuard';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
 import Version from '../../../package.json';
@@ -70,7 +70,7 @@ function DyvixFile({
         instanceId
       );
 
-      if (validator.status === GaurdStatus.Error) {
+      if (validator.status === GuardStatus.Error) {
         return EvaluateFailure(validator.error, validator.status);
       }
     }

--- a/src/components/file/validation.jsx
+++ b/src/components/file/validation.jsx
@@ -1,6 +1,6 @@
 import {
   EvaluateFailure,
-  GaurdStatus,
+  GuardStatus,
   allowsNull
 } from '../../utils/DyvixGuard';
 import { ValidatAndLoadJSON } from '../../utils/Smart Json Caching/SJCManager';
@@ -43,17 +43,17 @@ export async function Validatefile(animation, theme, callback, instance) {
   );
   if (!isAnimation.status && !allowsNull(normalizedAnimation)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid animation.'
     };
   }
 
   if (normalizedTheme !== '!/' && !isTheme.status) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid theme.'
     };
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }

--- a/src/components/input/validation.jsx
+++ b/src/components/input/validation.jsx
@@ -1,6 +1,6 @@
 import {
   EvaluateFailure,
-  GaurdStatus,
+  GuardStatus,
   allowsNull
 } from '../../utils/DyvixGuard';
 import { ValidatAndLoadJSON } from '../../utils/Smart Json Caching/SJCManager';
@@ -64,22 +64,22 @@ export async function Validateinput(
 
   if (!isAnimation.status && !allowsNull(normalizedAnimation)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid animation.'
     };
   }
   if (!isType.status && !allowsNull(normalizedType)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid type.'
     };
   }
   if (normalizedTheme !== '!/' && !isTheme.status) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid theme.'
     };
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }

--- a/src/components/modal/InputValidation.jsx
+++ b/src/components/modal/InputValidation.jsx
@@ -1,7 +1,7 @@
 import { validType, eleData, validRules } from './modal';
 import {
   EvaluateFailure,
-  GaurdStatus,
+  GuardStatus,
   allowsNull
 } from '../../utils/DyvixGuard';
 import { isValidRegex } from './dependencies/validator/validators';
@@ -72,7 +72,7 @@ export async function SerializeData(
   );
   supportedTypes = await getSupportedElements();
 
-  if (validator.status === GaurdStatus.Error) {
+  if (validator.status === GuardStatus.Error) {
     return EvaluateFailure(validator.error, validator.status);
   }
   const presetData = config.find((item) => item.preset);
@@ -82,7 +82,7 @@ export async function SerializeData(
   );
   const eleValidator = validateElements(normalizedElements);
 
-  if (eleValidator.status === GaurdStatus.Error) {
+  if (eleValidator.status === GuardStatus.Error) {
     return EvaluateFailure(eleValidator.error, eleValidator.status);
   }
   return normalizedElements;
@@ -125,7 +125,7 @@ export async function ValidateInput(
   if (preset !== '!/') {
     if (!isPreset.status) {
       return {
-        status: GaurdStatus.Error,
+        status: GuardStatus.Error,
         error: 'Please provide a valid preset.'
       };
     }
@@ -133,13 +133,13 @@ export async function ValidateInput(
 
   if (animation !== '!/' && !isAnimation.status && allowsNull(animation)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a vaild animation.'
     };
   }
   if (!isTheme.status && preset === '!/') {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a vaild theme.'
     };
   }
@@ -148,28 +148,28 @@ export async function ValidateInput(
 
   if (onSubmit !== undefined && typeof onSubmit !== 'function') {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'onSubmit should be provided as a function.'
     };
   }
-  if (preset !== '!/') return { status: GaurdStatus.Success };
+  if (preset !== '!/') return { status: GuardStatus.Success };
   if (title === '!/') {
-    return { status: GaurdStatus.Error, error: 'Please provide a title' };
+    return { status: GuardStatus.Error, error: 'Please provide a title' };
   }
   if (!validType.includes(type)) {
-    return { status: GaurdStatus.Error, error: 'Please provide a vaild type.' };
+    return { status: GuardStatus.Error, error: 'Please provide a vaild type.' };
   }
   if (
     !Array.isArray(elements) ||
     !elements.every((ele) => typeof ele === 'object')
   ) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Element should be provided as an array of objects.'
     };
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }
 export function validateElements(elements) {
   const MAX_ROWS = 9;
@@ -188,14 +188,14 @@ export function validateElements(elements) {
 
     if (!supportedTypes.includes(element.type)) {
       return {
-        status: GaurdStatus.Error,
+        status: GuardStatus.Error,
         error: 'Elements should include a valid type.'
       };
     }
     if (currentType['requires-options']) {
       if (!element.options || element.options.length === 0) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error: `Field '${element.name}' requires an options array.`
         };
       }
@@ -206,14 +206,14 @@ export function validateElements(elements) {
           element.options.length !== element.amount)
       ) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error: `Amount mismatch for '${element.name}'. Expected ${element.amount} option sets.`
         };
       }
     }
     if (element.amount < 1 || element.amount > 3) {
       return {
-        status: GaurdStatus.Error,
+        status: GuardStatus.Error,
         error: 'Element amount should be positive and less than 3.'
       };
     } else if (element.amount > 1) {
@@ -222,7 +222,7 @@ export function validateElements(elements) {
         element.placeholder.length !== element.amount
       ) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error:
             'Element placeholder should be provided as an array of the same length as the provided amount.'
         };
@@ -232,7 +232,7 @@ export function validateElements(elements) {
         element.name.length !== element.amount
       ) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error:
             'Element name should be provided as an array of the same length as the provided amount.'
         };
@@ -244,14 +244,14 @@ export function validateElements(elements) {
         )
       ) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error:
             'Element placeholder should be a string or an array of length 1.'
         };
       }
       if (!(Array.isArray(element.name) && element.name.length === 1)) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error: 'Element name should be a string or an array of length 1.'
         };
       }
@@ -265,7 +265,7 @@ export function validateElements(elements) {
 
     if (rules.length > element.amount) {
       return {
-        status: GaurdStatus.Error,
+        status: GuardStatus.Error,
         error: `Validation overflow: maximum of amount of ${element.amount} reached.`
       };
     }
@@ -279,13 +279,13 @@ export function validateElements(elements) {
 
         if (!isValidRegex(pattern)) {
           return {
-            status: GaurdStatus.Error,
+            status: GuardStatus.Error,
             error: `Invalid Regular Expression was provided.`
           };
         }
       } else if (!validRules.includes(rule)) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error: `'${rule}' is not a recognized validator.`
         };
       }
@@ -300,7 +300,7 @@ export function validateElements(elements) {
         );
         if (!exist) {
           return {
-            status: GaurdStatus.Error,
+            status: GuardStatus.Error,
             error: `'${matchId}' is not a recognized target for matching.`
           };
         }
@@ -311,14 +311,14 @@ export function validateElements(elements) {
   const isDuplicateName = checkDuplicates(elements, 'name');
   const isDuplicateId = checkDuplicates(elements, 'id');
 
-  if (isDuplicateName?.status === GaurdStatus.Error) {
+  if (isDuplicateName?.status === GuardStatus.Error) {
     return isDuplicateName;
   }
-  if (isDuplicateId?.status === GaurdStatus.Error) {
+  if (isDuplicateId?.status === GuardStatus.Error) {
     return isDuplicateId;
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }
 export function normalizeElements(elements) {
   return elements?.map((ele) => ({
@@ -342,7 +342,7 @@ function checkDuplicates(elements, field) {
       if (val === '!/') continue;
       if (found.has(val)) {
         return {
-          status: GaurdStatus.Error,
+          status: GuardStatus.Error,
           error: `Element ${field} should be unique.`
         };
       }
@@ -351,5 +351,5 @@ function checkDuplicates(elements, field) {
     }
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -20,7 +20,7 @@ import {
   normalizeElements,
   validateElements
 } from './InputValidation';
-import { GaurdStatus } from '../../utils/DyvixGuard';
+import { GuardStatus } from '../../utils/DyvixGuard';
 import Version from '../../../package.json';
 import DyvixButton from '../button/button';
 import DyvixFile from '../file/file';

--- a/src/components/toast/toastContainer.jsx
+++ b/src/components/toast/toastContainer.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { subscribe } from './bus';
 import { DyvixToastItem } from './toast';
 import { ValidateContainer } from './validation';
-import { GaurdStatus, EvaluateFailure } from '../../utils/DyvixGuard';
+import { GuardStatus, EvaluateFailure } from '../../utils/DyvixGuard';
 
 export const validPositions = positionData.map((e) => e.position);
 export const validTypes = TypesData.map((e) => e.type);
@@ -28,7 +28,7 @@ function DyvixToastContainer({
 }) {
   const validator = ValidateContainer(position, segments, duration, animation);
 
-  if (validator.status === GaurdStatus.Error) {
+  if (validator.status === GuardStatus.Error) {
     return EvaluateFailure(validator.error, validator.status);
   }
 

--- a/src/components/toast/validation.jsx
+++ b/src/components/toast/validation.jsx
@@ -1,6 +1,6 @@
 import {
   EvaluateFailure,
-  GaurdStatus,
+  GuardStatus,
   allowsNull
 } from '../../utils/DyvixGuard';
 import { validPositions, validAnimations, validTypes } from './toastContainer';
@@ -8,28 +8,28 @@ import { validPositions, validAnimations, validTypes } from './toastContainer';
 export function ValidateContainer(position, segments, duration, animation) {
   if (!validPositions.includes(position)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid position.'
     };
   }
   if (typeof duration !== 'number' || duration <= 0) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid duration that is greater than 0.'
     };
   }
   if (!validAnimations.includes(animation)) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a valid animation.'
     };
   }
   if (segments <= 0 || segments > 10) {
     return {
-      status: GaurdStatus.Error,
+      status: GuardStatus.Error,
       error: 'Please provide a segment between 1 and 10.'
     };
   }
 
-  return { status: GaurdStatus.Success };
+  return { status: GuardStatus.Success };
 }

--- a/src/utils/DyvixGuard.js
+++ b/src/utils/DyvixGuard.js
@@ -1,4 +1,4 @@
-export const GaurdStatus = {
+export const GuardStatus = {
   Error: 'error',
   Warn: 'warn',
   Log: 'log',
@@ -10,13 +10,13 @@ export function EvaluateFailure(message = '', status) {
   const formatedmsg = `${PREFIX} - ${message}`;
 
   switch (status) {
-    case GaurdStatus.Error:
+    case GuardStatus.Error:
       console.error(formatedmsg);
       return null;
-    case GaurdStatus.Warn:
+    case GuardStatus.Warn:
       console.warn(formatedmsg);
       break;
-    case GaurdStatus.Log:
+    case GuardStatus.Log:
       console.log(formatedmsg);
   }
 }

--- a/src/utils/Smart Json Caching/SJCManager.js
+++ b/src/utils/Smart Json Caching/SJCManager.js
@@ -1,4 +1,4 @@
-import { EvaluateFailure, GaurdStatus } from '../DyvixGuard';
+import { EvaluateFailure, GuardStatus } from '../DyvixGuard';
 import Version from '../../../package.json';
 import { set, get } from 'idb-keyval';
 import { CSS_LIBRARY, JSON_LIBRARY } from './SJCRegistry';


### PR DESCRIPTION
Closes #199

## Summary
- Bulk-renamed `GaurdStatus` -> `GuardStatus` across the codebase (60 occurrences, 11 files in \`src/\`).
- No functional change.

## Test plan
- [x] \`grep -r GaurdStatus src/\` returns nothing
- [ ] CI / existing tests pass