### PR TITLE
refactor: fix typo 'vaild' -> 'valid' in error messages

### DIFF
--- a/src/components/modal/InputValidation.jsx
+++ b/src/components/modal/InputValidation.jsx
@@ -134,13 +134,13 @@ export async function ValidateInput(
   if (animation !== '!/' && !isAnimation.status && allowsNull(animation)) {
     return {
       status: GaurdStatus.Error,
-      error: 'Please provide a vaild animation.'
+      error: 'Please provide a valid animation.'
     };
   }
   if (!isTheme.status && preset === '!/') {
     return {
       status: GaurdStatus.Error,
-      error: 'Please provide a vaild theme.'
+      error: 'Please provide a valid theme.'
     };
   }
 
@@ -157,7 +157,7 @@ export async function ValidateInput(
     return { status: GaurdStatus.Error, error: 'Please provide a title' };
   }
   if (!validType.includes(type)) {
-    return { status: GaurdStatus.Error, error: 'Please provide a vaild type.' };
+    return { status: GaurdStatus.Error, error: 'Please provide a valid type.' };
   }
   if (
     !Array.isArray(elements) ||

--- a/src/components/select/SelectCompiler.jsx
+++ b/src/components/select/SelectCompiler.jsx
@@ -191,10 +191,10 @@ function ValidateInput(elements, type, animation) {
     return { status: -1, error: 'Elements should be included as an array.' };
   }
   if (!supportedTypes.includes(type)) {
-    return { status: -1, error: 'Please provide a vaild select type.' };
+    return { status: -1, error: 'Please provide a valid select type.' };
   }
   if (animation !== '!/' && !validAnimations.includes(animation)) {
-    return { status: -1, error: 'Please provide a vaild animation.' };
+    return { status: -1, error: 'Please provide a valid animation.' };
   }
   return { status: 1 };
 }


### PR DESCRIPTION
Closes #200

## Summary
- Replaced 5 instances of \`vaild\` with \`valid\` in user-facing error messages
- Files: \`src/components/modal/InputValidation.jsx\`, \`src/components/select/SelectCompiler.jsx\`

## Test plan
- [x] \`grep -r vaild src/\` returns nothing