### PR TITLE
Add ocean input theme

### DIFF
--- a/src/components/input/dependencies/style/themes.css
+++ b/src/components/input/dependencies/style/themes.css
@@ -310,6 +310,84 @@
 .dyvix-input-sunset::placeholder {
   color: rgba(255, 255, 255, 0.5);
 }
+.dyvix-input-ocean {
+  background: #031b2f;
+  background: linear-gradient(
+    135deg,
+    #02131f 0%,
+    #05314b 35%,
+    #0b6c91 70%,
+    #38bdf8 100%
+  );
+  color: #e0f7ff;
+  border: 2px solid rgba(125, 211, 252, 0.55);
+  border-radius: 2rem;
+  box-shadow:
+    0px 0px 18px rgba(56, 189, 248, 0.45),
+    0px 0px 42px rgba(14, 165, 233, 0.35),
+    inset 0px 0px 18px rgba(186, 230, 253, 0.14);
+  -webkit-box-shadow:
+    0px 0px 18px rgba(56, 189, 248, 0.45),
+    0px 0px 42px rgba(14, 165, 233, 0.35),
+    inset 0px 0px 18px rgba(186, 230, 253, 0.14);
+  -moz-box-shadow:
+    0px 0px 18px rgba(56, 189, 248, 0.45),
+    0px 0px 42px rgba(14, 165, 233, 0.35),
+    inset 0px 0px 18px rgba(186, 230, 253, 0.14);
+  transition:
+    transform 0.35s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    -webkit-box-shadow 0.3s ease-in-out,
+    -moz-box-shadow 0.3s ease-in-out,
+    border-color 0.25s ease-in-out,
+    background 0.35s ease-in-out;
+}
+.dyvix-input-ocean:hover {
+  background: linear-gradient(
+    135deg,
+    #04243a 0%,
+    #065f86 40%,
+    #0ea5e9 75%,
+    #67e8f9 100%
+  );
+  border-color: rgba(186, 230, 253, 0.85);
+  transform: translateY(-1px) scale(1.01);
+  box-shadow:
+    0px 0px 24px rgba(56, 189, 248, 0.65),
+    0px 0px 60px rgba(14, 165, 233, 0.5),
+    inset 0px 0px 24px rgba(186, 230, 253, 0.2);
+  -webkit-box-shadow:
+    0px 0px 24px rgba(56, 189, 248, 0.65),
+    0px 0px 60px rgba(14, 165, 233, 0.5),
+    inset 0px 0px 24px rgba(186, 230, 253, 0.2);
+  -moz-box-shadow:
+    0px 0px 24px rgba(56, 189, 248, 0.65),
+    0px 0px 60px rgba(14, 165, 233, 0.5),
+    inset 0px 0px 24px rgba(186, 230, 253, 0.2);
+}
+.dyvix-input-ocean:focus {
+  outline: none;
+  border-color: #bae6fd;
+  transform: scale(1.015);
+  box-shadow:
+    0px 0px 0px 2px rgba(125, 211, 252, 0.28),
+    0px 0px 30px rgba(56, 189, 248, 0.75),
+    0px 0px 70px rgba(14, 165, 233, 0.6),
+    inset 0px 0px 28px rgba(224, 247, 255, 0.24);
+  -webkit-box-shadow:
+    0px 0px 0px 2px rgba(125, 211, 252, 0.28),
+    0px 0px 30px rgba(56, 189, 248, 0.75),
+    0px 0px 70px rgba(14, 165, 233, 0.6),
+    inset 0px 0px 28px rgba(224, 247, 255, 0.24);
+  -moz-box-shadow:
+    0px 0px 0px 2px rgba(125, 211, 252, 0.28),
+    0px 0px 30px rgba(56, 189, 248, 0.75),
+    0px 0px 70px rgba(14, 165, 233, 0.6),
+    inset 0px 0px 28px rgba(224, 247, 255, 0.24);
+}
+.dyvix-input-ocean::placeholder {
+  color: rgba(224, 247, 255, 0.72);
+}
 .dyvix-input-forest {
   background: #1f3b2c;
   background: radial-gradient(

--- a/src/components/input/dependencies/themes.json
+++ b/src/components/input/dependencies/themes.json
@@ -40,6 +40,11 @@
     "default-animation": "drop"
   },
   {
+    "theme": "Ocean",
+    "class": "dyvix-input-ocean",
+    "default-animation": "wave"
+  },
+  {
     "theme": "Forest",
     "class": "dyvix-input-forest",
     "default-animation": "glide"

--- a/src/components/input/dependencies/themes.json
+++ b/src/components/input/dependencies/themes.json
@@ -42,7 +42,7 @@
   {
     "theme": "Ocean",
     "class": "dyvix-input-ocean",
-    "default-animation": "wave"
+    "default-animation": "flip"
   },
   {
     "theme": "Forest",


### PR DESCRIPTION
## Summary

Adds a new Ocean input theme.

## Changes

- Added `.dyvix-input-ocean` styling with a blue ocean gradient
- Added hover and focus glow states so it matches the visual style of the other animated input themes
- Registered the Ocean theme in `themes.json` with the `wave` default animation

## Testing

I was not able to fully test the theme switcher locally, but I checked that the theme name, class name, and default animation are wired correctly.