### PR TITLE
feat(input): add Crimson theme support

### DIFF
--- a/src/components/input/dependencies/style/themes.css
+++ b/src/components/input/dependencies/style/themes.css
@@ -363,3 +363,33 @@
     inset 0 0 20px rgba(112, 168, 247, 0.2);
   transform: translateY(-2px) scale(1.01);
 }
+.dyvix-input-crimson {
+  background: #1a0000;
+  color: #ffd6d6;
+  border: 1px solid #ff4d4d;
+  border-radius: 10px;
+  box-shadow: 0 0 18px rgba(255, 77, 77, 0.25);
+  transition:
+    border-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.2s ease,
+    background-color 0.25s ease;
+}
+.dyvix-input-crimson:hover {
+  background: #2a0000;
+  border-color: #ff6666;
+  box-shadow: 0 0 24px rgba(255, 77, 77, 0.4);
+  transform: scale(1.01);
+}
+.dyvix-input-crimson:focus {
+  outline: none;
+  background: #2a0000;
+  border-color: #ff8080;
+  box-shadow:
+    0 0 28px rgba(255, 77, 77, 0.55),
+    0 0 0 2px rgba(255, 77, 77, 0.18);
+}
+
+.dyvix-input-crimson::placeholder {
+  color: rgba(255, 214, 214, 0.7);
+}

--- a/src/components/input/dependencies/themes.json
+++ b/src/components/input/dependencies/themes.json
@@ -48,5 +48,10 @@
     "theme": "Midnight",
     "class": "dyvix-input-midnight",
     "default-animation": "drift"
+  },
+  {
+    "theme": "Crimson",
+    "class": "dyvix-input-crimson",
+    "default-animation": "glitch"
   }
 ]

--- a/src/components/input/dependencies/themes.json
+++ b/src/components/input/dependencies/themes.json
@@ -52,6 +52,6 @@
   {
     "theme": "Crimson",
     "class": "dyvix-input-crimson",
-    "default-animation": "glitch"
+    "default-animation": "float"
   }
 ]


### PR DESCRIPTION
## Summary
Adds Crimson theme support to the input registry.

## Changes
- Added Crimson theme entry to input themes.json
- Added dyvix-input-crimson styles in themes.css
- Regenerated constants using npm run dyvix:build

## Testing
- Ran npm run dyvix:build successfully
- Verified generated constants updated correctly

close #214 