### PR TITLE
docs: add input theme attribute

### DIFF
--- a/docs/components/input/input.md
+++ b/docs/components/input/input.md
@@ -4,7 +4,7 @@ title: Dyvix Input
 
 # Dyvix Input
 
-A config-driven animated input component with support for default coloring styles.
+A config-driven animated input component with support for themed and default coloring styles.
 
 ## Attributes
 
@@ -14,6 +14,8 @@ A config-driven animated input component with support for default coloring style
   - : `string`. The text displayed when the input is empty.
 - `autoComplete`
   - : `string`. The autocomplete hint passed to the underlying input element.
+- `theme`
+  - : `string`. Controls the design and the feel of the input. See the [Themes list](/guide/themes) for a full list.
 - `background`
   - : `string`. Controls the input background color and feel.
 - `color`
@@ -48,11 +50,12 @@ A config-driven animated input component with support for default coloring style
 ## Example
 
 ```jsx
-import { DyvixInput, DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+import { DyvixInput, DYVIX_GLOBAL_ANIMATION, DYVIX_GLOBAL_THEME } from 'dyvix-ui';
 function InputExample() {
   return (
     <DyvixInput
       animation={DYVIX_GLOBAL_ANIMATION.AURORA}
+      theme={DYVIX_GLOBAL_THEME.MIDNIGHT}
       type="text"
       placeholder="Enter your name"
       onChange={(e) => {


### PR DESCRIPTION
Closes #221

## Summary
- add the missing `theme` attribute to `docs/components/input/input.md`
- update the page intro to mention themed styling support
- extend the example to show `DYVIX_GLOBAL_THEME` usage with `DyvixInput`

## Affected page
- `docs/components/input/input.md`
- local docs route: `/components/input/input`

## Validation
- `npm run dyvix:build`
- `npm run docs:build`
