### PR TITLE
Add theme selector to input playground

### DIFF
--- a/docs/.vitepress/theme/components/input/InputPlayground.jsx
+++ b/docs/.vitepress/theme/components/input/InputPlayground.jsx
@@ -1,7 +1,7 @@
 import { DyvixInput } from 'dyvix-ui';
 import Wrapper from '../Wrapper';
 import React from 'react';
-import { DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+import { DYVIX_GLOBAL_ANIMATION, DYVIX_GLOBAL_THEME } from 'dyvix-ui';
 
 export default function InputPlayground() {
   const [config, setConfig] = React.useState([
@@ -19,6 +19,14 @@ export default function InputPlayground() {
       },
       current: 'text',
       format: 'string'
+    },
+    {
+      utility: 'theme',
+      type: 'select',
+      options: DYVIX_GLOBAL_THEME,
+      current: DYVIX_GLOBAL_THEME.OCEAN,
+      format: 'string',
+      allowNull: false
     },
     {
       utility: 'animation',
@@ -72,6 +80,7 @@ export default function InputPlayground() {
   ]);
 
   const type = config.find((e) => e.utility === 'type').current;
+  const theme = config.find((e) => e.utility === 'theme').current;
   const animation = config.find((e) => e.utility === 'animation').current;
   const placeholder = config.find((e) => e.utility === 'placeholder').current;
   const name = config.find((e) => e.utility === 'name').current;
@@ -83,6 +92,7 @@ export default function InputPlayground() {
 
   const props = {
     ...(type && { type }),
+    ...(theme && { theme }),
     ...(animation && { animation }),
     ...(placeholder && { placeholder }),
     ...(name && { name }),

--- a/docs/.vitepress/theme/components/input/InputPlayground.jsx
+++ b/docs/.vitepress/theme/components/input/InputPlayground.jsx
@@ -68,7 +68,7 @@ export default function InputPlayground() {
     {
       utility: 'background',
       type: 'color',
-      current: '#32374e',
+      current: undefined,
       format: 'string'
     },
     {


### PR DESCRIPTION
## Problem

Fixes #222.

The Input docs playground was missing a theme selector, so users could not change the `theme` prop from the playground UI.

## Solution

Added a `theme` select option to `InputPlayground.jsx` using the existing `DYVIX_GLOBAL_THEME` options.

The selected theme is now read from the playground config and passed into `DyvixInput` through the component props.

## Testing

Manually tested by opening the Input docs page and confirming that the theme selector appears and works as expected when switching themes.

<img width="1050" height="1695" alt="image" src="https://github.com/user-attachments/assets/ddee3232-88ac-45e0-b49b-3bc6e0c72462" />
