### PR TITLE
Add Ocean theme for labels

### DIFF
--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -45,6 +45,24 @@
     0px 4px 12px rgba(255, 69, 0, 0.9),
     0px 0px 30px rgba(255, 69, 0, 0.5);
 }
+.dyvix-label-ocean {
+  font-family: 'Geist';
+  color: #e0f7ff;
+  text-shadow:
+    0 0 8px rgba(56, 189, 248, 0.55),
+    0 0 22px rgba(14, 165, 233, 0.35);
+  transition:
+    color 0.3s ease-in-out,
+    text-shadow 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
+}
+.dyvix-label-ocean:hover {
+  color: #67e8f9;
+  text-shadow:
+    0 0 12px rgba(125, 211, 252, 0.75),
+    0 0 34px rgba(14, 165, 233, 0.55);
+  transform: translateY(-1px);
+}
 .dyvix-label-crimson {
   font-family: 'Geist';
   color: #dc143c;

--- a/src/components/label/dependencies/themes.json
+++ b/src/components/label/dependencies/themes.json
@@ -15,6 +15,11 @@
     "default-animation": "glitch"
   },
   {
+    "theme": "Ocean",
+    "class": "dyvix-label-ocean",
+    "default-animation": "flip"
+  },
+  {
     "theme": "Crimson",
     "class": "dyvix-label-crimson",
     "default-animation": "float"


### PR DESCRIPTION
## Summary
- register the `Ocean` theme for the label component
- add the matching `.dyvix-label-ocean` CSS class using the existing Ocean color language

Fixes #230.

## Validation
- `npm ci`
- `npm run dyvix:build`
- `node --check dev-engine/scripts/generate-constants.js`
- `node -e "const fs = require('fs'); const themes = require('./src/components/label/dependencies/themes.json'); const css = fs.readFileSync('./src/components/label/dependencies/style/themes.css', 'utf8'); const ocean = themes.find((theme) => theme.theme === 'Ocean'); if (!ocean || ocean.class !== 'dyvix-label-ocean' || ocean['default-animation'] !== 'flip' || !css.includes('.dyvix-label-ocean')) process.exit(1);"`
- `git diff --check`

## Notes
`npm ci` reported two pre-existing moderate audit findings. I did not change dependencies for this theme-only update.
