### PR TITLE
Docs: Add background attribute to modal documentation and playground

### DIFF
--- a/docs/.vitepress/theme/components/modal/ModalPlayground.jsx
+++ b/docs/.vitepress/theme/components/modal/ModalPlayground.jsx
@@ -29,6 +29,12 @@ export default function ModalPlayground() {
       allowNull: false
     },
     {
+      utility: 'background',
+      type: 'color',
+      current: undefined,
+      format: 'string'
+    },
+    {
       utility: 'title',
       type: 'text',
       current: 'Register',
@@ -116,6 +122,7 @@ export default function ModalPlayground() {
 
   const theme = config.find((e) => e['utility'] === 'theme').current;
   const animation = config.find((e) => e['utility'] === 'animation').current;
+  const background = config.find((e) => e['utility'] === 'background')?.current;
   const title = config.find((e) => e['utility'] === 'title').current;
   const type = config.find((e) => e['utility'] === 'type').current;
   const elements = config.find((e) => e['utility'] === 'elements').current;
@@ -124,6 +131,7 @@ export default function ModalPlayground() {
   const probs = {
     ...(theme && { theme: theme }),
     ...(animation && { animation: animation }),
+    ...(background && { background: background }),
     ...(title && { title: title }),
     ...(type && { type: type }),
     ...(elements && { elements: elements }),

--- a/docs/components/modal/modal.md
+++ b/docs/components/modal/modal.md
@@ -25,6 +25,8 @@ The modal component is a core Dyvix UI component. It's a config driven, animated
   - : `string`. Represents the type of the modal. Defaults to `form`. Supported types are `form` and `auth`.
 - `theme`
   - : `string`. Controls the design and the feel of the modal. See the [Themes list](/guide/themes) for a full list.
+- `background`
+  - : `string`. Controls the modal background color.
 - `animation`
   - : `string`. Controls the entrance animation of the modal. See the [Animation List](/guide/animations) for a full list.
 - `preset`


### PR DESCRIPTION
## Description

Added `background` attribute documentation to modal.md and a background color selector to ModalPlayground.jsx.

Closes #234, Closes #235

---
*If this PR adds value, consider [buying me a coffee](https://buymeacoffee.com/gitscopetools)*