### PR TITLE
Add forest label theme

### DIFF
--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -81,3 +81,21 @@
     0px 4px 12px rgba(220, 20, 60, 0.9),
     0px 0px 30px rgba(220, 20, 60, 0.5);
 }
+.dyvix-label-forest {
+  font-family: 'Geist';
+  color: #86a86b;
+  text-shadow:
+    0 0 8px rgba(163, 236, 101, 0.45),
+    0 0 20px rgba(75, 58, 42, 0.4);
+  transition:
+    color 0.3s ease-in-out,
+    text-shadow 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
+}
+.dyvix-label-forest:hover {
+  color: #a3ec65;
+  text-shadow:
+    0 0 12px rgba(163, 236, 101, 0.75),
+    0 0 30px rgba(75, 58, 42, 0.6);
+  transform: translateY(-1px);
+}

--- a/src/components/label/dependencies/themes.json
+++ b/src/components/label/dependencies/themes.json
@@ -23,5 +23,10 @@
     "theme": "Crimson",
     "class": "dyvix-label-crimson",
     "default-animation": "float"
+  },
+  {
+    "theme": "Forest",
+    "class": "dyvix-label-forest",
+    "default-animation": "glide"
   }
 ]

--- a/src/components/label/label.jsx
+++ b/src/components/label/label.jsx
@@ -11,7 +11,7 @@ import Version from '../../../package.json';
  * @param {string} [props.className] - Label className
  * @param {string} [props.htmlFor] - Links the label to a form associated element
  * @param {string} [props.animation] - Animation name
- * @param {('Singularity'|'Industrial'|'Ember'|'Frost'|'Blade'|'Neon'|'Aurora'|'Sunset'|'Crimson'|'Midnight')} [props.theme] - Label theme
+ * @param {('Singularity'|'Industrial'|'Ember'|'Frost'|'Blade'|'Neon'|'Aurora'|'Sunset'|'Crimson'|'Midnight'|'Forest')} [props.theme] - Label theme
  * @param {Object} [props.style] - Inline styles overrides
 */
 function DyvixLabel({


### PR DESCRIPTION
## Problem
Fixes #229.

Adds the missing Forest theme option for the `DyvixLabel` component.

## Solution
- Added `Forest` to the label theme options.
- Registered the Forest label theme in the label themes config.
- Added `.dyvix-label-forest` styling using the existing Forest color palette from the modal theme.
- Included hover styling with a green glow effect to match the existing label theme pattern.

## Testing
- Tested locally in the devbench by applying the Forest theme to a label.
- Confirmed the label receives the `dyvix-label-forest` class and displays the new Forest styling.

<img width="301" height="34" alt="image" src="https://github.com/user-attachments/assets/de06de71-bd36-4c7d-b3dc-1a1ec557ed49" />
