### PR TITLE
feat: implement Label playground

### DIFF
--- a/docs/.vitepress/theme/components/label/LabelPlayground.jsx
+++ b/docs/.vitepress/theme/components/label/LabelPlayground.jsx
@@ -1,0 +1,48 @@
+import { DyvixLabel } from 'dyvix-ui';
+import Wrapper from '../Wrapper';
+import React from 'react';
+import { DYVIX_GLOBAL_THEME, DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+
+export default function LabelPlayground() {
+  const [config, setConfig] = React.useState([
+    {
+      utility: 'theme',
+      type: 'select',
+      options: DYVIX_GLOBAL_THEME,
+      current: DYVIX_GLOBAL_THEME.OCEAN,
+      format: 'string'
+    },
+    {
+      utility: 'animation',
+      type: 'select',
+      options: DYVIX_GLOBAL_ANIMATION,
+      current: DYVIX_GLOBAL_ANIMATION.FADE,
+      format: 'string'
+    },
+    {
+      utility: 'children',
+      type: 'text',
+      current: 'Label Text',
+      format: 'string'
+    }
+  ]);
+
+  const theme = config.find((e) => e['utility'] === 'theme').current;
+  const animation = config.find((e) => e['utility'] === 'animation').current;
+  const children = config.find((e) => e['utility'] === 'children').current;
+  const probs = {
+    ...(theme && { theme: theme }),
+    ...(animation && { animation: animation })
+  };
+  return (
+    <Wrapper
+      componentConfig={config}
+      componentCallback={setConfig}
+      tag={'DyvixLabel'}
+    >
+      <DyvixLabel htmlFor="demo-input" {...probs}>
+        {children}
+      </DyvixLabel>
+    </Wrapper>
+  );
+}

--- a/docs/.vitepress/theme/components/label/LabelPlayground.vue
+++ b/docs/.vitepress/theme/components/label/LabelPlayground.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { onMounted, ref } from 'vue';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import LabelPlayground from './LabelPlayground';
+
+const container = ref(null);
+
+onMounted(() => {
+  ReactDOM.createRoot(container.value).render(
+    React.createElement(LabelPlayground)
+  );
+});
+</script>
+
+<template>
+  <div ref="container"></div>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import FilePlayground from './components/file/FilePlayground.vue';
 import InputPlayground from './components/input/InputPlayground.vue';
 import ModalPlayground from './components/modal/ModalPlayground.vue';
 import SelectPlayground from './components/select/SelectPlayground.vue';
+import LabelPlayground from './components/label/LabelPlayground.vue';
 import './custom.css';
 
 export default {
@@ -14,5 +15,6 @@ export default {
     app.component('InputPlayground', InputPlayground);
     app.component('ModalPlayground', ModalPlayground);
     app.component('SelectPlayground', SelectPlayground);
+    app.component('LabelPlayground', LabelPlayground);
   }
 };

--- a/docs/components/label/label.md
+++ b/docs/components/label/label.md
@@ -20,7 +20,11 @@ A config-driven animated label component with support for themed and default col
 ## Example
 
 ```jsx
-import { DyvixLabel, DYVIX_GLOBAL_ANIMATION, DYVIX_GLOBAL_THEME } from 'dyvix-ui';
+import {
+  DyvixLabel,
+  DYVIX_GLOBAL_ANIMATION,
+  DYVIX_GLOBAL_THEME
+} from 'dyvix-ui';
 
 function LabelExample() {
   return (
@@ -34,3 +38,7 @@ function LabelExample() {
   );
 }
 ```
+
+## Try it
+
+<LabelPlayground />


### PR DESCRIPTION
Closes #240

Implemented the interactive playground for the `DyvixLabel` component as requested. Followed the same patterns as the Button playground.