### PR TITLE
Add Frost theme for Label component

### DIFF
--- a/devbench/src/component/label.jsx
+++ b/devbench/src/component/label.jsx
@@ -6,7 +6,7 @@ export function LabelTest() {
       <DyvixLabel
         htmlFor="hh"
         animation={DYVIX_GLOBAL_ANIMATION.DRIFT}
-        theme={DYVIX_GLOBAL_THEME.CRIMSON}
+        theme={DYVIX_GLOBAL_THEME.FROST}
       >
         Enter your name
       </DyvixLabel>

--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -45,6 +45,28 @@
     0px 4px 12px rgba(255, 69, 0, 0.9),
     0px 0px 30px rgba(255, 69, 0, 0.5);
 }
+.dyvix-label-frost {
+  font-family: 'Geist';
+  color: rgba(213, 255, 248, 1);
+  border-bottom: 2px groove #ffffff40;
+  padding-bottom: 2px;
+  text-shadow:
+    0 0 8px rgba(213, 255, 248, 0.65),
+    0 0 20px rgba(248, 248, 248, 0.25);
+  transition:
+    color 0.3s ease-in-out,
+    border-color 0.2s ease-in-out,
+    text-shadow 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
+}
+.dyvix-label-frost:hover {
+  color: #f8f8f8;
+  border-bottom-color: #f8f8f840;
+  text-shadow:
+    0 0 12px rgba(213, 255, 248, 0.8),
+    0 0 30px rgba(248, 248, 248, 0.35);
+  transform: translateY(-1px);
+}
 .dyvix-label-ocean {
   font-family: 'Geist';
   color: #e0f7ff;

--- a/src/components/label/dependencies/themes.json
+++ b/src/components/label/dependencies/themes.json
@@ -15,6 +15,11 @@
     "default-animation": "glitch"
   },
   {
+    "theme": "Frost",
+    "class": "dyvix-label-frost",
+    "default-animation": "unfold"
+  },
+  {
     "theme": "Ocean",
     "class": "dyvix-label-ocean",
     "default-animation": "flip"


### PR DESCRIPTION
## Summary
- add Frost to the label theme registry with the `dyvix-label-frost` class
- add Frost label styling consistent with the existing global Frost visual language
- update the devbench label example to exercise the Frost theme

## Validation
- `npm run build -w devbench`

Note: the build passes with the existing Vite warning about `src/constants.js` being both statically and dynamically imported by modal validation code.