### PR TITLE
feat(label): add midnight theme #224

### DIFF
--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -105,7 +105,7 @@
 }
 .dyvix-label-midnight {
   font-family: 'Geist';
-  color: #00106b;
+  color: #7aaaff;
   text-shadow:
     0 0 8px rgba(112, 168, 247, 0.5),
     0 0 22px rgba(99, 102, 241, 0.35);
@@ -115,7 +115,7 @@
     transform 0.3s ease-in-out;
 }
 .dyvix-label-midnight:hover {
-  color: #001a8f;
+  color: #a0c4ff;
   text-shadow:
     0 0 12px rgba(112, 168, 247, 0.7),
     0 0 34px rgba(99, 102, 241, 0.55);

--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -103,6 +103,24 @@
     0px 4px 12px rgba(220, 20, 60, 0.9),
     0px 0px 30px rgba(220, 20, 60, 0.5);
 }
+.dyvix-label-midnight {
+  font-family: 'Geist';
+  color: #00106b;
+  text-shadow:
+    0 0 8px rgba(112, 168, 247, 0.5),
+    0 0 22px rgba(99, 102, 241, 0.35);
+  transition:
+    color 0.3s ease-in-out,
+    text-shadow 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
+}
+.dyvix-label-midnight:hover {
+  color: #001a8f;
+  text-shadow:
+    0 0 12px rgba(112, 168, 247, 0.7),
+    0 0 34px rgba(99, 102, 241, 0.55);
+  transform: translateY(-1px);
+}
 .dyvix-label-forest {
   font-family: 'Geist';
   color: #86a86b;

--- a/src/components/label/dependencies/themes.json
+++ b/src/components/label/dependencies/themes.json
@@ -30,6 +30,11 @@
     "default-animation": "float"
   },
   {
+    "theme": "Midnight",
+    "class": "dyvix-label-midnight",
+    "default-animation": "drift"
+  },
+  {
     "theme": "Forest",
     "class": "dyvix-label-forest",
     "default-animation": "glide"


### PR DESCRIPTION
Fixes #224

**Summary**

- Added the Midnight theme to the Label component theme list
- Added the matching dyvix-label-midnight CSS class
- Styled the label using the existing Midnight modal theme as inspiration, while keeping the Label                              component’s existing text/glow pattern

**Testing**

- Ran the project locally with npm run dev
- Confirmed the Midnight label theme displays correctly
- Confirmed the hover styling works as expected

<img width="209" height="31" alt="MidnightTHEME" src="https://github.com/user-attachments/assets/bcf9b7a9-4cd1-419d-badf-3f19513fde61" />
