### PR TITLE
feat(label): add blade theme #242

### DIFF
--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -67,6 +67,19 @@
     0 0 30px rgba(248, 248, 248, 0.35);
   transform: translateY(-1px);
 }
+.dyvix-label-blade {
+  font-family: 'Geist';
+  color: #e2e8f0;
+  border-bottom: 2px solid #ffffff20;
+  padding-bottom: 2px;
+  transition:
+    color 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
+}
+.dyvix-label-blade:hover {
+  color: #ffffff;
+  border-bottom-color: #ffffff;
+}
 .dyvix-label-ocean {
   font-family: 'Geist';
   color: #e0f7ff;

--- a/src/components/label/dependencies/themes.json
+++ b/src/components/label/dependencies/themes.json
@@ -20,6 +20,11 @@
     "default-animation": "unfold"
   },
   {
+    "theme": "Blade",
+    "class": "dyvix-label-blade",
+    "default-animation": "Zoom"
+  },
+  {
     "theme": "Ocean",
     "class": "dyvix-label-ocean",
     "default-animation": "flip"


### PR DESCRIPTION
Fixes #242

## Summary
- Added the Blade theme to the Label component theme list
- Added the matching `dyvix-label-blade` CSS class
- Styled the label using the existing Blade modal theme as inspiration while keeping the Label component’s  existing styling pattern

## Testing
- Ran the project locally with `npm run dev`
- Confirmed the Blade label theme displays correctly
- Confirmed the hover styling works as expected

<img width="202" height="26" alt="Screenshot 2026-06-13 173133" src="https://github.com/user-attachments/assets/2f602b98-898b-4d70-b354-be084148bffe" />

<img width="210" height="42" alt="Screenshot 2026-06-13 173121" src="https://github.com/user-attachments/assets/d9bbd459-e5e8-4e6e-936c-a407fb84d0f3" />
