### PR TITLE
Add Crimson theme support to Table component

### DIFF
--- a/devbench/src/component/table.jsx
+++ b/devbench/src/component/table.jsx
@@ -12,7 +12,7 @@ export function TableTest() {
     <>
        <DyvixTable
         animation={DYVIX_GLOBAL_ANIMATION.DRIFT}
-        theme={DYVIX_GLOBAL_THEME.SINGULARITY}
+        theme={DYVIX_GLOBAL_THEME.CRIMSON}
         columns={[
           { key: 'id', label: 'ID' },
           { key: 'name', label: 'Name' },

--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -23,7 +23,7 @@
 .dyvix-table-crimson {
   border-radius: 1rem;
   font-family: 'Geist';
-  border: 4px solid #ff4d4d;
+  border: 2px solid #ff4d4d;
   color: #ffd6d6;
   background-color: #1a0000;
   background: radial-gradient(circle, #1a0000 0%, #0d0000 100%);
@@ -35,8 +35,7 @@
     background ease-in-out 0.2s;
 }
 .dyvix-table-crimson:hover {
-  border: 4px solid #ff6666;
   background: radial-gradient(circle, #2a0000 0%, #0d0000 120%);
   box-shadow: 0 0 50px rgba(255, 77, 77, 0.45);
-  transform: scale(1.02);
+  transform: scale(1.009);
 }

--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -20,3 +20,23 @@
   box-shadow: 0 0 50px #b903e2;
   transform: scale(1.02);
 }
+.dyvix-table-crimson {
+  border-radius: 1rem;
+  font-family: 'Geist';
+  border: 4px solid #ff4d4d;
+  color: #ffd6d6;
+  background-color: #1a0000;
+  background: radial-gradient(circle, #1a0000 0%, #0d0000 100%);
+  box-shadow: 0 0 30px rgba(255, 77, 77, 0.25);
+  transition:
+    transform ease-in-out 0.7s,
+    box-shadow ease-in-out 0.6s,
+    border ease-in-out 0.3s,
+    background ease-in-out 0.2s;
+}
+.dyvix-table-crimson:hover {
+  border: 4px solid #ff6666;
+  background: radial-gradient(circle, #2a0000 0%, #0d0000 120%);
+  box-shadow: 0 0 50px rgba(255, 77, 77, 0.45);
+  transform: scale(1.02);
+}

--- a/src/components/table/dependencies/themes.json
+++ b/src/components/table/dependencies/themes.json
@@ -4,7 +4,6 @@
     "class": "dyvix-table-lens",
     "default-animation": "bubble"
   },
-
   {
     "theme": "Crimson",
     "class": "dyvix-table-crimson",

--- a/src/components/table/dependencies/themes.json
+++ b/src/components/table/dependencies/themes.json
@@ -3,5 +3,11 @@
     "theme": "Singularity",
     "class": "dyvix-table-lens",
     "default-animation": "bubble"
+  },
+
+  {
+    "theme": "Crimson",
+    "class": "dyvix-table-crimson",
+    "default-animation": "float"
   }
 ]


### PR DESCRIPTION
Adds the Crimson global theme to the Table component, matching the existing theme set in Button, Modal, Input, and File.
Changes:
- Added Crimson entry in `src/components/table/dependencies/themes.json`
- Added `.dyvix-table-crimson` CSS class in `src/components/table/dependencies/style/themes.css`
- Updated `devbench/table.jsx` to test the new theme