### PR TITLE
feat(table): add Midnight theme support

### DIFF
--- a/devbench/src/component/table.jsx
+++ b/devbench/src/component/table.jsx
@@ -12,7 +12,7 @@ export function TableTest() {
     <>
       <DyvixTable
         animation={DYVIX_GLOBAL_ANIMATION.DRIFT}
-        theme={DYVIX_GLOBAL_THEME.CRIMSON}
+        theme={DYVIX_GLOBAL_THEME.MIDNIGHT}
         columns={[
           { key: 'id', label: 'ID' },
           { key: 'name', label: 'Name' },
@@ -28,7 +28,7 @@ export function TableTest() {
           { id: 5, name: 'Bear', type: 'Wild', hp: 90, region: 'Amr' }
         ]}
       />
-      <DyvixTable>
+      <DyvixTable theme={DYVIX_GLOBAL_THEME.MIDNIGHT} animation={DYVIX_GLOBAL_ANIMATION.DRIFT}>
         <DyvixTableHeader>
           <DyvixTableRow>
             <DyvixTableHead>Vehicle</DyvixTableHead>

--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -73,5 +73,5 @@
   -moz-box-shadow:
     0 0 60px 10px rgba(99, 102, 241, 0.4),
     inset 0 0 20px rgba(112, 168, 247, 0.2);
-  transform: translateY(-3px) scale(1.01);
+  transform: translateY(-3px) scale(1.005);
 }

--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -39,3 +39,39 @@
   box-shadow: 0 0 50px rgba(255, 77, 77, 0.45);
   transform: scale(1.009);
 }
+
+.dyvix-table-midnight {
+  border-radius: 1rem;
+  font-family: 'Geist';
+  background: radial-gradient(circle at center, #00024d 0%, #000000 100%);
+  border: 1px solid rgba(112, 168, 247, 0.3);
+  color: #c8d8f8;
+  box-shadow:
+    0 0 40px 5px rgba(99, 102, 241, 0.2),
+    inset 0 0 15px rgba(112, 168, 247, 0.1);
+  -webkit-box-shadow:
+    0 0 40px 5px rgba(99, 102, 241, 0.2),
+    inset 0 0 15px rgba(112, 168, 247, 0.1);
+  -moz-box-shadow:
+    0 0 40px 5px rgba(99, 102, 241, 0.2),
+    inset 0 0 15px rgba(112, 168, 247, 0.1);
+  backdrop-filter: blur(10px);
+  transition:
+    transform 0.5s cubic-bezier(0.17, 0.88, 0.3, 1.67),
+    box-shadow 0.5s ease-in-out,
+    border-color 0.3s ease-in-out;
+}
+.dyvix-table-midnight:hover {
+  background: radial-gradient(circle at 40% 40%, #000375 0%, #000000 100%);
+  border-color: rgba(112, 168, 247, 0.6);
+  box-shadow:
+    0 0 60px 10px rgba(99, 102, 241, 0.4),
+    inset 0 0 20px rgba(112, 168, 247, 0.2);
+  -webkit-box-shadow:
+    0 0 60px 10px rgba(99, 102, 241, 0.4),
+    inset 0 0 20px rgba(112, 168, 247, 0.2);
+  -moz-box-shadow:
+    0 0 60px 10px rgba(99, 102, 241, 0.4),
+    inset 0 0 20px rgba(112, 168, 247, 0.2);
+  transform: translateY(-3px) scale(1.01);
+}

--- a/src/components/table/dependencies/themes.json
+++ b/src/components/table/dependencies/themes.json
@@ -8,5 +8,10 @@
     "theme": "Crimson",
     "class": "dyvix-table-crimson",
     "default-animation": "float"
+  },
+  {
+    "theme": "Midnight",
+    "class": "dyvix-table-midnight",
+    "default-animation": "drift"
   }
 ]


### PR DESCRIPTION
Added support for the midnight global theme in the table registry.
<img width="1919" height="877" alt="image" src="https://github.com/user-attachments/assets/478b2b79-54bc-434c-9b3d-b8a653365687" />

Fixes #266 