### PR TITLE
feat(table): add Blade theme to the table registry

### DIFF
--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -239,3 +239,30 @@
 
   transform: translateY(-2px) scale(1.009);
 }
+
+.dyvix-table-blade {
+  border-radius: 0px;
+  font-family: 'Geist';
+  background-color: #0a0a0a;
+  color: #e2e8f0;
+  border-left: 3px solid #e2e8f0;
+  border-top: 3px solid #e2e8f0;
+  border-right: 1px solid #ffffff20;
+  border-bottom: 1px solid #ffffff20;
+  box-shadow: -4px -4px 20px rgba(255, 255, 255, 0.05);
+  -webkit-box-shadow: -4px -4px 20px rgba(255, 255, 255, 0.05);
+  -moz-box-shadow: -4px -4px 20px rgba(255, 255, 255, 0.05);
+  transition:
+    border-left 0.1s ease-in-out,
+    border-top 0.1s ease-in-out,
+    box-shadow 0.2s ease-in-out,
+    transform 0.3s ease-in-out;
+}
+.dyvix-table-blade:hover {
+  border-left: 4px solid #ffffff;
+  border-top: 4px solid #ffffff;
+  box-shadow: -6px -6px 30px rgba(255, 255, 255, 0.1);
+  -webkit-box-shadow: -6px -6px 30px rgba(255, 255, 255, 0.1);
+  -moz-box-shadow: -6px -6px 30px rgba(255, 255, 255, 0.1);
+  transform: translateY(-2px) scale(1.005);
+}

--- a/src/components/table/dependencies/themes.json
+++ b/src/components/table/dependencies/themes.json
@@ -33,5 +33,10 @@
     "theme": "Neon",
     "class": "dyvix-table-neon",
     "default-animation": "pulse"
+  },
+  {
+    "theme": "Blade",
+    "class": "dyvix-table-blade",
+    "default-animation": "drift"
   }
 ]


### PR DESCRIPTION
Closes #286.

Ports the existing global `Blade` theme to the table component:
- Adds a `Blade` entry in `table/dependencies/themes.json` (class `dyvix-table-blade`, `drift` animation).
- Adds the matching `.dyvix-table-blade` CSS in `table/dependencies/style/themes.css`, mirroring the Blade styling used by the button/file/input components (sharp 0px corners, asymmetric bright top-left borders, dark background, soft top-left glow) and the table theme conventions (Geist font, hover transform).

Verified locally: `dyvix:build` (generate-constants) runs clean and `themes.json` parses with the new entry.