### PR TITLE
fix(docs): correct 'represet' typo to 'represent'

### DIFF
--- a/docs/components/modal/elements.md
+++ b/docs/components/modal/elements.md
@@ -7,7 +7,7 @@ next:
 
 # Modal Elements
 
-Modal elements represet the specific type of the fields present in the modal
+Modal elements represent the specific type of the fields present in the modal
 
 ## Available elements
 

--- a/docs/components/modal/presets.md
+++ b/docs/components/modal/presets.md
@@ -7,7 +7,7 @@ next:
 
 # Modal Presets
 
-Modal presets represet a premade config for common modal usecases.
+Modal presets represent a premade config for common modal usecases.
 
 ## Available elements
 


### PR DESCRIPTION
Fixes spelling mistake and replaced 'represet' to 'represent' in elements.md and presets.md. Closes #302.