### PR TITLE
fix(docs): correct heading typo in modal presets documentation

### DIFF
--- a/docs/components/modal/presets.md
+++ b/docs/components/modal/presets.md
@@ -9,7 +9,7 @@ next:
 
 Modal presets represet a premade config for common modal usecases.
 
-## Available elements
+## Available presets
 
 Dyvix provides a wide range of presets. You can trigger these by passing the string name.
 


### PR DESCRIPTION
Fixes a heading typo in `docs/components/modal/presets.md`, replacing `Available elements` with `Available presets` as described in #301.
Fixes #301
---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._