### PR TITLE
docs: fix "represet" typo -> "represent" in modal docs

### DIFF
--- a/docs/components/modal/elements.md
+++ b/docs/components/modal/elements.md
@@ -7,7 +7,7 @@ next:
 
 # Modal Elements
 
-Modal elements represet the specific type of the fields present in the modal
+Modal elements represent the specific type of the fields present in the modal
 
 ## Available elements
 

--- a/docs/components/modal/presets.md
+++ b/docs/components/modal/presets.md
@@ -7,7 +7,7 @@ next:
 
 # Modal Presets
 
-Modal presets represet a premade config for common modal usecases.
+Modal presets represent a premade config for common modal usecases.
 
 ## Available elements
 


### PR DESCRIPTION
## Summary

Fixes the `represet` → `represent` spelling typo in the modal docs, as described in #302.

## Changes

- `docs/components/modal/elements.md` — "Modal elements ~~represet~~ **represent** the specific type of the fields..."
- `docs/components/modal/presets.md` — "Modal presets ~~represet~~ **represent** a premade config..."

A full case-insensitive scan of the repository (excluding `node_modules`) confirms these were the only two occurrences of the typo, so the docs are now clean.

Closes #302
