### PR TITLE
feat(table): add Frost theme

### DIFF
--- a/docs/components/modal/elements.md
+++ b/docs/components/modal/elements.md
@@ -7,7 +7,7 @@ next:
 
 # Modal Elements
 
-Modal elements represet the specific type of the fields present in the modal
+Modal elements represent the specific type of the fields present in the modal
 
 ## Available elements
 

--- a/docs/components/modal/presets.md
+++ b/docs/components/modal/presets.md
@@ -7,7 +7,7 @@ next:
 
 # Modal Presets
 
-Modal presets represet a premade config for common modal usecases.
+Modal presets represent a premade config for common modal usecases.
 
 ## Available elements
 

--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -294,3 +294,28 @@
   -moz-box-shadow: 0px 0px 55px 0px rgba(1, 176, 179, 0.55);
   transform: translateY(-2px) scale(1.005);
 }
+
+.dyvix-table-frost {
+  border-radius: 1rem;
+  font-family: 'Geist';
+  background-color: #ffffff1a;
+  border: 5px groove #ffffff40;
+  color: #d5fff8;
+  backdrop-filter: blur(50px);
+  box-shadow: -6px 2px 51px -7px rgba(213, 255, 248, 1) inset;
+  -webkit-box-shadow: -6px 2px 51px -7px rgba(213, 255, 248, 1) inset;
+  -moz-box-shadow: -6px 2px 51px -7px rgba(213, 255, 248, 1) inset;
+  transition:
+    transform 0.5s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    -webkit-box-shadow 0.3s ease-in-out,
+    -moz-box-shadow 0.3s ease-in-out,
+    border 0.2s ease-in-out;
+}
+.dyvix-table-frost:hover {
+  border: 8px groove #f8f8f840;
+  transform: scale(1.005);
+  box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
+  -webkit-box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
+  -moz-box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
+}

--- a/src/components/table/dependencies/themes.json
+++ b/src/components/table/dependencies/themes.json
@@ -43,5 +43,10 @@
     "theme": "Aurora",
     "class": "dyvix-table-aurora",
     "default-animation": "aurora"
+  },
+  {
+    "theme": "Frost",
+    "class": "dyvix-table-frost",
+    "default-animation": "float"
   }
 ]


### PR DESCRIPTION
## Summary

Ports the global **Frost** theme to the table component, as requested in #295. The table registry previously had no Frost theme even though it exists globally (`DYVIX_GLOBAL_THEME.FROST`) and in the modal/button/file/input/label components.

## Changes

- **`src/components/table/dependencies/themes.json`** — add the `Frost` theme entry (`class: dyvix-table-frost`, `default-animation: float`).
- **`src/components/table/dependencies/style/themes.css`** — add the `.dyvix-table-frost` (and `:hover`) class.

The CSS reuses the frosted-glass identity shared by the existing Frost themes (translucent white surface, `groove` border, `backdrop-filter: blur`, icy inset glow) while following the table theme conventions already used by the other table themes (`border-radius: 1rem`, `font-family: 'Geist'`, a readable icy `color`, and a subtle `scale` hover).

## Notes / testing

- `themes.json` is valid JSON and the `dyvix-table-frost` class name matches between the JSON entry and the CSS.
- The table validator (`src/components/table/validation.jsx`) resolves a theme by looking it up in `themes.json` and falls back to its `default-animation`, so the new entry makes `theme="Frost"` fully functional — e.g. `<DyvixTable theme={DYVIX_GLOBAL_THEME.FROST}>`.
- The change is purely additive and follows the exact pattern of the surrounding themes, so no existing themes are affected.

Closes #295
