### PR TITLE
docs(modal): update modal preset list to include missing presets

### DIFF
--- a/docs/components/modal/presets.md
+++ b/docs/components/modal/presets.md
@@ -15,6 +15,9 @@ Dyvix provides a wide range of presets. You can trigger these by passing the str
 
 - `'Register'`
 - `'Login'`
+- `'ForgotPassword'`
+- `'ResetPassword'`
+- `'ChangePassword'`
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Closes #300.

The modal preset list in [`docs/components/modal/presets.md`](https://github.com/younisdev/dyvix-ui/blob/main/docs/components/modal/presets.md) was outdated and only listed `Register` and `Login`. This PR adds the remaining presets defined under the `DYVIX_MODAL_PRESET` key in [`src/constants.js`](https://github.com/younisdev/dyvix-ui/blob/main/src/constants.js):

- `ForgotPassword`
- `ResetPassword`
- `ChangePassword`

The preset list now matches the source of truth in `constants.js`.

## Changes
- Added the three missing presets to the "Available presets" list in `presets.md`.

## Notes
- Change is documentation-only (a single markdown list). No source/behavior changes.