### PR TITLE
docs(select): add theme selector to the Select playground

### DIFF
--- a/docs/.vitepress/theme/components/select/SelectPlayground.jsx
+++ b/docs/.vitepress/theme/components/select/SelectPlayground.jsx
@@ -1,7 +1,7 @@
 import { DyvixSelect } from 'dyvix-ui';
 import Wrapper from '../Wrapper';
 import React from 'react';
-import { DYVIX_GLOBAL_ANIMATION } from 'dyvix-ui';
+import { DYVIX_GLOBAL_ANIMATION, DYVIX_GLOBAL_THEME } from 'dyvix-ui';
 
 export default function SelectPlayground() {
   const [config, setConfig] = React.useState([
@@ -14,6 +14,14 @@ export default function SelectPlayground() {
       },
       current: 'select',
       format: 'string'
+    },
+    {
+      utility: 'theme',
+      type: 'select',
+      options: DYVIX_GLOBAL_THEME,
+      current: DYVIX_GLOBAL_THEME.SINGULARITY,
+      format: 'string',
+      allowNull: false
     },
     {
       utility: 'animation',
@@ -31,10 +39,12 @@ export default function SelectPlayground() {
   ]);
 
   const type = config.find((e) => e.utility === 'type').current;
+  const theme = config.find((e) => e.utility === 'theme').current;
   const animation = config.find((e) => e.utility === 'animation').current;
   const placeholder = config.find((e) => e.utility === 'placeholder').current;
   const props = {
     ...(type && { type }),
+    ...(theme && { theme }),
     ...(animation && { animation }),
     ...(placeholder && { placeholder })
   };


### PR DESCRIPTION
## Summary

Closes #297.

The Dyvix select component playground didn't expose a theme control. This adds a `theme` selector to [`SelectPlayground.jsx`](docs/.vitepress/theme/components/select/SelectPlayground.jsx), mirroring the setup already used in [`ModalPlayground.jsx`](docs/.vitepress/theme/components/modal/ModalPlayground.jsx).

## Changes

- Import `DYVIX_GLOBAL_THEME`.
- Add a `theme` utility entry (`type: 'select'`, `options: DYVIX_GLOBAL_THEME`) to the playground config, defaulting to `DYVIX_GLOBAL_THEME.SINGULARITY`.
- Read the selected `theme` and pass it through to `<DyvixSelect>` via the existing `props` spread.

## Testing

- `npx prettier --check` passes on the changed file.
- `npm run docs:dev` — the Select playground now shows a **Theme** dropdown, and changing it updates the live `<DyvixSelect>` preview.
