### PR TITLE
docs(select): document the theme attribute on the Select page

### DIFF
--- a/docs/components/select/select.md
+++ b/docs/components/select/select.md
@@ -17,6 +17,8 @@ A config-driven animated select component with support for normal and autocomple
   - : `function`. A callback function triggered every time the select value changes. It receives the value directly.
 - `type`
   - : `string`. The type of the select component. Defaults to `select`.
+- `theme`
+  - : `string`. Controls the design and the feel of the select. See the [Themes list](/guide/themes) for a full list.
 - `animation`
   - : `string`. Controls the entrance animation of the select. See the [Animation Presets](/guide/animations) for a full list.
 - `className`
@@ -43,6 +45,7 @@ function SelectExample() {
     <DynamicSelect
       className="ex-select"
       type="select"
+      theme="Singularity"
       elements={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
       onChange={(data) => console.log(data)}
     />


### PR DESCRIPTION
## Summary

Closes #298.

The `DyvixSelect` docs page had no reference to theme support. This documents the `theme` attribute on [`select.md`](docs/components/select/select.md), matching how it's documented on the modal and button pages.

## Changes

- Add the `theme` attribute to the **Attributes** list, linking to the [Themes list](/guide/themes) (same wording as `modal.md` / `button.md`).
- Add `theme="Singularity"` to the example snippet so the usage is shown.

## Testing

- `npx prettier --check` passes on the changed file.
- `npm run docs:dev` — the Select docs page now lists the `theme` attribute and the example shows its usage.
