### PR TITLE
docs: replace DynamicSelect references

### DIFF
--- a/docs/components/select/select.md
+++ b/docs/components/select/select.md
@@ -38,11 +38,11 @@ Dyvix Select Includes 2 types of select each type behaving differnetly:
 ## Example
 
 ```jsx
-import { DynamicSelect } from 'dyvix-ui';
+import { DyvixSelect } from 'dyvix-ui';
 
 function SelectExample() {
   return (
-    <DynamicSelect
+    <DyvixSelect
       className="ex-select"
       type="select"
       theme="Singularity"

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -64,11 +64,11 @@ function ModalExample() {
 ## 3 - Setup basic select
 
 ```jsx
-import { DynamicSelect } from 'dyvix-ui';
+import { DyvixSelect } from 'dyvix-ui';
 
 function SelectExample() {
   return (
-    <DynamicSelect
+    <DyvixSelect
       className="ex-select"
       type="select"
       elements={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}


### PR DESCRIPTION
## Summary
- replace leftover `DynamicSelect` examples with `DyvixSelect`
- update both select component docs and quickstart docs

## Validation
- rg "DynamicSelect|DyvixSelect" docs src README.md

Closes #311