### PR TITLE
feat: add background and dropdownBackground controls to select playground

### DIFF
--- a/docs/.vitepress/theme/components/select/SelectPlayground.jsx
+++ b/docs/.vitepress/theme/components/select/SelectPlayground.jsx
@@ -31,6 +31,18 @@ export default function SelectPlayground() {
       format: 'string'
     },
     {
+      utility: 'background',
+      type: 'color',
+      current: undefined,
+      format: 'string'
+    },
+    {
+      utility: 'dropdownBackground',
+      type: 'color',
+      current: undefined,
+      format: 'string'
+    },
+    {
       utility: 'placeholder',
       type: 'text',
       current: 'Select an option',
@@ -41,13 +53,20 @@ export default function SelectPlayground() {
   const type = config.find((e) => e.utility === 'type').current;
   const theme = config.find((e) => e.utility === 'theme').current;
   const animation = config.find((e) => e.utility === 'animation').current;
+  const background = config.find((e) => e.utility === 'background')?.current;
+  const dropdownBackground = config.find(
+    (e) => e.utility === 'dropdownBackground'
+  )?.current;
   const placeholder = config.find((e) => e.utility === 'placeholder').current;
   const props = {
     ...(type && { type }),
     ...(theme && { theme }),
     ...(animation && { animation }),
+    ...(background && { background }),
+    ...(dropdownBackground && { dropdownBackground }),
     ...(placeholder && { placeholder })
   };
+
   return (
     <Wrapper
       componentConfig={config}

--- a/src/components/select/SelectEngine.jsx
+++ b/src/components/select/SelectEngine.jsx
@@ -72,7 +72,7 @@ const SelectEngine = forwardRef(
         itemsRef.current[activeIndex].scrollIntoView({ block: 'nearest' });
       }
     }, [activeIndex]);
-console.log(background)
+
     return (
       <>
         {is_rendered && (
@@ -80,7 +80,10 @@ console.log(background)
             className={`dyvix-dropdown-select ${className}`.trim()}
             role="listbox"
             ref={ref}
-            style={{...(background && {'--dyvix-select-dropdown-color': background})}}
+            style={{
+              ...(background && { background })
+            }}
+
           >
             {is_open &&
               elements.map((element, index) => (

--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -46,7 +46,7 @@
   border-radius: 0px;
 }
 .dyvix-select-industrial .dyvix-select-dropdown-industrial {
-  background: #2c3e50;
+  background: var(--dyvix-select-dropdown-color, #2c3e50);
   border: 1px solid #374151;
   border-radius: 0px;
 }

--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -18,7 +18,7 @@
   color: rgba(185, 3, 226, 0.4);
 }
 .dyvix-select-lens .dyvix-select-dropdown-lens {
-  background: #0d0d0d;
+  background: var(--dyvix-select-dropdown-color, #0d0d0d);
   border: 1px solid rgba(185, 3, 226, 0.3);
   border-radius: 8px;
   box-shadow: 0 0 20px rgba(185, 3, 226, 0.2);


### PR DESCRIPTION
## Summary
- Added `background` and `dropdownBackground` controls to the Dyvix Select playground.
- Wired the dropdown background to the selected value.
- Updated the select theme to use the configurable dropdown background while preserving the default fallback.

Fixes #320