### PR TITLE
feat(select): add Ember theme

### DIFF
--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -57,3 +57,56 @@
   .dyvix-select-dropdown-industrial::-webkit-scrollbar-thumb {
   background: #0a1429;
 }
+/* Ember Theme */
+.dyvix-select-ember .dyvix-select-input-ember {
+  background: #0f0a08;
+  border: none;
+  border-bottom: 3px solid #ff4500;
+  color: #ffffff;
+  border-radius: 10px;
+  box-shadow:
+    0px 8px 12px -6px rgba(255, 69, 0, 0.6),
+    0px 0px 20px -8px rgba(255, 69, 0, 0.3);
+  transition:
+    border-bottom 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    transform 0.2s ease-in-out;
+}
+
+.dyvix-select-ember .dyvix-select-input-ember:hover {
+  border-bottom-color: #ff6b00;
+  box-shadow:
+    0px 10px 18px -6px rgba(255, 69, 0, 0.8),
+    0px 0px 30px -6px rgba(255, 69, 0, 0.45);
+}
+
+.dyvix-select-ember .dyvix-select-input-ember:focus {
+  border-bottom-color: #ff6b00;
+  outline: none;
+}
+
+.dyvix-select-ember .dyvix-select-input-ember::placeholder {
+  color: rgba(255, 160, 122, 0.6);
+}
+
+.dyvix-select-ember .dyvix-select-dropdown-ember {
+  background: var(--dyvix-select-dropdown-color, #0f0a08);
+  border: 1px solid rgba(255, 69, 0, 0.35);
+  border-radius: 10px;
+  box-shadow: 0px 0px 25px rgba(255, 69, 0, 0.2);
+
+  --dyvix-select-active-bg: #ff4500;
+  --dyvix-select-active-text: #ffffff;
+}
+
+.dyvix-select-ember .dyvix-select-dropdown-ember li {
+  color: #ffffff;
+}
+
+.dyvix-select-ember .dyvix-select-dropdown-ember li:hover {
+  background: rgba(255, 69, 0, 0.15);
+}
+
+.dyvix-select-ember .dyvix-select-dropdown-ember::-webkit-scrollbar-thumb {
+  background: rgba(255, 69, 0, 0.6);
+}

--- a/src/components/select/dependencies/themes.json
+++ b/src/components/select/dependencies/themes.json
@@ -18,6 +18,6 @@
     "class": "dyvix-select-ember",
     "input-class": "dyvix-select-input-ember",
     "dropdown-class": "dyvix-select-dropdown-ember",
-    "default-animation": "fade"
+    "default-animation": "glitch"
   }
 ]

--- a/src/components/select/dependencies/themes.json
+++ b/src/components/select/dependencies/themes.json
@@ -12,5 +12,12 @@
     "input-class": "dyvix-select-input-industrial",
     "dropdown-class": "dyvix-select-dropdown-industrial",
     "default-animation": "fade"
+  },
+  {
+    "theme": "Ember",
+    "class": "dyvix-select-ember",
+    "input-class": "dyvix-select-input-ember",
+    "dropdown-class": "dyvix-select-dropdown-ember",
+    "default-animation": "fade"
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds support for the **Ember** theme to the Select component.

### Changes

* Added the **Ember** theme entry to `src/components/select/dependencies/themes.json`.
* Added Ember-specific styles to `src/components/select/dependencies/style/themes.css`.
* Verified the theme locally using the devbench.

Closes #333.
