### PR TITLE
docs: add Obsidian theme

### DIFF
--- a/docs/guide/themes.md
+++ b/docs/guide/themes.md
@@ -24,3 +24,4 @@ Dyvix provides a wide range of themes. You can trigger these by passing the stri
 - `DYVIX_GLOBAL_THEME.OCEAN`: `'Ocean'`
 - `DYVIX_GLOBAL_THEME.FOREST`: `'Forest'`
 - `DYVIX_GLOBAL_THEME.MIDNIGHT`: `'Midnight'`
+- `DYVIX_GLOBAL_THEME.OBSIDIAN`: `'Obsidian'`


### PR DESCRIPTION
## Summary

Added the missing **Obsidian** theme to the themes documentation (`docs/guide/themes.md`) using the exported `DYVIX_GLOBAL_THEME.OBSIDIAN` constant.

## Related Issue

Closes #344