### PR TITLE
docs: add swing animation to animations list

### DIFF
--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -25,4 +25,4 @@ Dyvix provides a wide range of smooth animations. You can trigger these by passi
 - `DYVIX_GLOBAL_ANIMATION.GLIDE`: `'glide'`
 - `DYVIX_GLOBAL_ANIMATION.DRIFT`: `'drift'`
 - `DYVIX_GLOBAL_ANIMATION.FLOAT`: `'float'`
-- DYVIX_GLOBAL_ANIMATION.SWING : 'swing'
+- `DYVIX_GLOBAL_ANIMATION.SWING`: `'swing'`

--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -25,3 +25,4 @@ Dyvix provides a wide range of smooth animations. You can trigger these by passi
 - `DYVIX_GLOBAL_ANIMATION.GLIDE`: `'glide'`
 - `DYVIX_GLOBAL_ANIMATION.DRIFT`: `'drift'`
 - `DYVIX_GLOBAL_ANIMATION.FLOAT`: `'float'`
+- DYVIX_GLOBAL_ANIMATION.SWING : 'swing'


### PR DESCRIPTION
## Summary
- Added the missing `DYVIX_GLOBAL_ANIMATION.SWING` entry to `docs/guide/animations.md`.

Fixes #342