### PR TITLE
feat(select): add Neon select theme

### DIFF
--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -110,3 +110,53 @@
 .dyvix-select-ember .dyvix-select-dropdown-ember::-webkit-scrollbar-thumb {
   background: rgba(255, 69, 0, 0.6);
 }
+
+/* Neon Theme */
+.dyvix-select-neon .dyvix-select-input-neon {
+  border: 2px solid rgba(252, 46, 255, 0.4);
+  background: radial-gradient(
+    circle,
+    rgba(77, 238, 234, 1) 0%,
+    rgba(112, 186, 239, 1) 43%,
+    rgba(240, 0, 255, 1) 100%
+  );
+  color: #ffffff;
+  box-shadow: 0px 0px 24px rgba(252, 46, 255, 0.5);
+  border-radius: 2rem;
+  transition:
+    border-radius 0.2s ease-in-out,
+    transform 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out;
+}
+.dyvix-select-neon .dyvix-select-input-neon:hover {
+  border-radius: 1rem;
+  transform: scale(1.01);
+  box-shadow: 0px 0px 40px rgba(252, 46, 255, 0.7);
+}
+.dyvix-select-neon .dyvix-select-input-neon:focus {
+  border-color: rgba(252, 46, 255, 0.8);
+  outline: none;
+}
+.dyvix-select-neon .dyvix-select-input-neon::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+.dyvix-select-neon .dyvix-select-dropdown-neon {
+  background: var(--dyvix-select-dropdown-color, #0d0d0d);
+  border: 1px solid rgba(252, 46, 255, 0.4);
+  border-radius: 1rem;
+  box-shadow: 0px 0px 30px rgba(252, 46, 255, 0.3);
+  --dyvix-select-active-bg: #f02eff;
+  --dyvix-select-active-text: #ffffff;
+}
+.dyvix-select-neon .dyvix-select-dropdown-neon li {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid rgba(252, 46, 255, 0.15);
+}
+.dyvix-select-neon .dyvix-select-dropdown-neon li:hover {
+  background: rgba(252, 46, 255, 0.2);
+  color: white;
+}
+.dyvix-select-neon .dyvix-select-dropdown-neon::-webkit-scrollbar-thumb {
+  background: rgba(252, 46, 255, 0.6);
+}

--- a/src/components/select/dependencies/themes.json
+++ b/src/components/select/dependencies/themes.json
@@ -19,5 +19,12 @@
     "input-class": "dyvix-select-input-ember",
     "dropdown-class": "dyvix-select-dropdown-ember",
     "default-animation": "glitch"
+  },
+  {
+    "theme": "Neon",
+    "class": "dyvix-select-neon",
+    "input-class": "dyvix-select-input-neon",
+    "dropdown-class": "dyvix-select-dropdown-neon",
+    "default-animation": "pulse"
   }
 ]


### PR DESCRIPTION
## Summary
Ports the global `Neon` theme (already used by the modal component) to the select component's theme registry, per #351.

## Change
- `src/components/select/dependencies/themes.json`: added a `Neon` entry (`dyvix-select-neon` / `dyvix-select-input-neon` / `dyvix-select-dropdown-neon`, `default-animation: pulse` — matching modal's Neon animation).
- `src/components/select/dependencies/style/themes.css`: added the corresponding `.dyvix-select-neon .dyvix-select-input-neon` and `.dyvix-select-neon .dyvix-select-dropdown-neon` rule blocks (base/hover/focus/placeholder for the input, base/li/li:hover/scrollbar for the dropdown), following the same structure as the existing Lens/Industrial/Ember select themes and reusing modal's Neon color palette (cyan-to-magenta radial gradient, magenta glow shadow).

## Testing
- Verified `themes.json` is valid JSON and the new theme object matches the shape of existing entries.
- Verified the new CSS selectors follow the exact same nesting pattern (`.dyvix-select-{theme} .dyvix-select-input-{theme}` / `.dyvix-select-{theme} .dyvix-select-dropdown-{theme}`) used by every other select theme, so `dev-engine/scripts/check-themes.js` will now detect `Neon` as present for the `select` component.
- `DYVIX_GLOBAL_THEME.NEON` already exists in `src/constants.js` (auto-generated, consumed by modal), so no changes were needed there.

Closes #351