### PR TITLE
Add obsidian theme for table

### DIFF
--- a/devbench/src/component/table.jsx
+++ b/devbench/src/component/table.jsx
@@ -12,7 +12,7 @@ export function TableTest() {
     <>
       <DyvixTable
         animation={DYVIX_GLOBAL_ANIMATION.PULSE}
-        theme={DYVIX_GLOBAL_THEME.INDUSTRIAL}
+        theme={DYVIX_GLOBAL_THEME.OBSIDIAN}
         columns={[
           { key: 'id', label: 'ID', sortable: true },
           { key: 'name', label: 'Name', sortable: true },
@@ -29,7 +29,7 @@ export function TableTest() {
         ]}
       />
       <DyvixTable
-        theme={DYVIX_GLOBAL_THEME.INDUSTRIAL}
+        theme={DYVIX_GLOBAL_THEME.OBSIDIAN}
         animation={DYVIX_GLOBAL_ANIMATION.PULSE}
       >
         <DyvixTableHeader>

--- a/src/components/table/dependencies/style/themes.css
+++ b/src/components/table/dependencies/style/themes.css
@@ -424,3 +424,37 @@
   -webkit-box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
   -moz-box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
 }
+.dyvix-table-obsidian {
+  border-radius: 1rem;
+  font-family: 'Geist';
+
+  background: radial-gradient(
+    circle at top,
+    #2a2a2a 0%,
+    #151515 45%,
+    #050505 100%
+  );
+
+  color: #f3f4f6;
+
+  border: 2px solid rgba(160, 130, 255, 0.4);
+
+  box-shadow:
+    inset 0 0 40px rgba(255, 255, 255, 0.04),
+    0 0 50px rgba(120, 90, 255, 0.18);
+
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.dyvix-table-obsidian:hover {
+  transform: translateY(-2px);
+
+  box-shadow:
+    inset 0 0 30px rgba(255, 255, 255, 0.05),
+    0 0 75px rgba(130, 100, 255, 0.25);
+
+  border-color: rgba(180, 150, 255, 0.7);
+}


### PR DESCRIPTION
## Description
Added a new Obsidian theme for the DyvixTable component.

## Changes Made
- Added `DYVIX_GLOBAL_THEME.OBSIDIAN` support in the table devbench example.
- Introduced new `.dyvix-table-obsidian` styles in `themes.css`.
- Updated table styling to provide a dark, modern Obsidian-inspired appearance.

## Testing
- Verified the new theme renders correctly in the table component.
- Checked that existing table themes remain unaffected.

## Related Issue
Closes #355 