### PR TITLE
refactor: standardize theme naming and remove hardcoded workaround

### DIFF
--- a/dev-engine/scripts/check-themes.js
+++ b/dev-engine/scripts/check-themes.js
@@ -61,11 +61,6 @@ function getMissingThemes(targetComponent) {
   }
 
   globalThemes.forEach((theme) => {
-    // temp fix for an inconsistent naming
-    // to be removed
-    if (targetComponent !== 'table') {
-      theme = theme === 'Singularity' ? 'Lens' : theme;
-    }
 
     const expectedClass = `.dyvix-${targetComponent}-${theme.toLowerCase()}`;
     const match = CheckCSSClass(expectedClass, rawCSS);

--- a/src/components/button/dependencies/style/themes.css
+++ b/src/components/button/dependencies/style/themes.css
@@ -1,4 +1,4 @@
-.dyvix-button-lens {
+.dyvix-button-singularity {
   background: radial-gradient(circle, #000000 0%, #1a1a1a 100%);
   box-shadow: 0 0 30px #b903e2;
   -webkit-box-shadow: 0 0 30px #b903e2;
@@ -7,11 +7,11 @@
   border-radius: 10rem;
   transition: all 0.3s ease-in-out;
 }
-.dyvix-button-lens:hover {
+.dyvix-button-singularity:hover {
   border: #000000 3px double;
   transform: scale(1.09);
 }
-.dyvix-button-lens:active {
+.dyvix-button-singularity:active {
   border: #000000 5px double;
   transform: scale(1.09);
 }

--- a/src/components/button/dependencies/themes.json
+++ b/src/components/button/dependencies/themes.json
@@ -1,7 +1,7 @@
 [
   {
     "theme": "Singularity",
-    "class": "dyvix-button-lens",
+    "class": "dyvix-button-singularity",
     "default-animation": "bubble"
   },
   {

--- a/src/components/file/dependencies/style/themes.css
+++ b/src/components/file/dependencies/style/themes.css
@@ -1,4 +1,4 @@
-.dyvix-file-lens {
+.dyvix-file-singularity {
   border: 4px dashed #3c0349;
   background-color: #1f2937;
   background: radial-gradient(circle, #000000 0%, #1a1a1a 100%);
@@ -10,16 +10,16 @@
     background 0.3s ease-in-out,
     transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
-.dyvix-file-lens p {
+.dyvix-file-singularity p {
   color: whitesmoke;
   transition: color 0.2s ease;
 }
-.dyvix-file-lens:hover {
+.dyvix-file-singularity:hover {
   border-color: #6a2a7a;
   background: rgb(47, 4, 47);
   transform: scale(1.02);
 }
-.dyvix-file-lens:hover p {
+.dyvix-file-singularity:hover p {
   color: grey;
 }
 .dyvix-file-industrial {

--- a/src/components/file/dependencies/themes.json
+++ b/src/components/file/dependencies/themes.json
@@ -1,7 +1,7 @@
 [
   {
     "theme": "Singularity",
-    "class": "dyvix-file-lens",
+    "class": "dyvix-file-singularity",
     "default-animation": "bubble"
   },
   {

--- a/src/components/input/dependencies/style/themes.css
+++ b/src/components/input/dependencies/style/themes.css
@@ -1,4 +1,4 @@
-.dyvix-input-lens {
+.dyvix-input-singularity {
   background: radial-gradient(circle, #000000 0%, #1a1a1a 100%);
   color: #b903e2;
   box-shadow: 0 0 30px #b903e2;
@@ -8,15 +8,15 @@
   border-radius: 10rem;
   transition: all 0.3s ease-in-out;
 }
-.dyvix-input-lens:hover {
+.dyvix-input-singularity:hover {
   border-color: #6a0368;
   box-shadow: 0 0 50px #b903e2;
   transform: scale(1.02);
 }
-.dyvix-input-lens::placeholder {
+.dyvix-input-singularity::placeholder {
   color: whitesmoke;
 }
-.dyvix-input-lens:focus {
+.dyvix-input-singularity:focus {
   border-color: #b903e2;
   box-shadow:
     0 0 50px #b903e2,

--- a/src/components/input/dependencies/themes.json
+++ b/src/components/input/dependencies/themes.json
@@ -1,7 +1,7 @@
 [
   {
     "theme": "Singularity",
-    "class": "dyvix-input-lens",
+    "class": "dyvix-input-singularity",
     "default-animation": "bubble"
   },
   {

--- a/src/components/label/dependencies/style/themes.css
+++ b/src/components/label/dependencies/style/themes.css
@@ -1,4 +1,4 @@
-.dyvix-label-lens {
+.dyvix-label-singularity {
   font-family: 'Geist';
   color: #b903e2;
   text-shadow:
@@ -8,7 +8,7 @@
     color 0.3s ease-in-out,
     text-shadow 0.3s ease-in-out;
 }
-.dyvix-label-lens:hover {
+.dyvix-label-singularity:hover {
   color: white;
   text-shadow:
     0 0 12px #b903e2,

--- a/src/components/label/dependencies/themes.json
+++ b/src/components/label/dependencies/themes.json
@@ -1,7 +1,7 @@
 [
   {
     "theme": "Singularity",
-    "class": "dyvix-label-lens",
+    "class": "dyvix-label-singularity",
     "default-animation": "bubble"
   },
   {

--- a/src/components/modal/dependencies/style/themes.css
+++ b/src/components/modal/dependencies/style/themes.css
@@ -1,4 +1,4 @@
-.dyvix-modal-lens {
+.dyvix-modal-singularity {
   font-family: 'Geist';
   border: 4px solid #3c0349;
   color: white;
@@ -15,13 +15,13 @@
     border ease-in-out 0.3s,
     background ease-in-out 0.2s;
 }
-.dyvix-modal-lens:hover {
+.dyvix-modal-singularity:hover {
   border: 4px solid #27032f;
   background: radial-gradient(circle, #000000 0%, #1a1a1a 120%);
   box-shadow: 0 0 50px #b903e2;
   transform: scale(1.02);
 }
-.dyvix-modal-lens > div > .modal-text {
+.dyvix-modal-singularity > div > .modal-text {
   color: white;
 }
 .dyvix-modal-industrial {

--- a/src/components/modal/dependencies/themes.json
+++ b/src/components/modal/dependencies/themes.json
@@ -1,7 +1,7 @@
 [
   {
     "theme": "Singularity",
-    "class": "dyvix-modal-lens",
+    "class": "dyvix-modal-singularity",
     "default-animation": "bubble",
     "radiused": true
   },

--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -1,23 +1,23 @@
-.dyvix-select-lens .dyvix-select-input-lens {
+.dyvix-select-singularity .dyvix-select-input-singularity {
   border: 2px solid #3c0349;
   background: radial-gradient(circle, #000000 0%, #1a1a1a 100%);
   color: white;
   box-shadow: 0 0 12px rgba(185, 3, 226, 0.3);
   border-radius: 8px;
 }
-.dyvix-select-lens .dyvix-select-input-lens:hover {
+.dyvix-select-singularity .dyvix-select-input-singularity:hover {
   border-color: #7a0499;
   box-shadow: 0 0 20px rgba(185, 3, 226, 0.45);
 }
-.dyvix-select-lens .dyvix-select-input-lens:focus {
+.dyvix-select-singularity .dyvix-select-input-singularity:focus {
   border-color: #b903e2;
   box-shadow: 0 0 25px rgba(185, 3, 226, 0.6);
   background: radial-gradient(circle, #0d0d0d 0%, #1a1a1a 100%);
 }
-.dyvix-select-lens .dyvix-select-input-lens::placeholder {
+.dyvix-select-singularity .dyvix-select-input-singularity::placeholder {
   color: rgba(185, 3, 226, 0.4);
 }
-.dyvix-select-lens .dyvix-select-dropdown-lens {
+.dyvix-select-singularity .dyvix-select-dropdown-singularity {
   background: var(--dyvix-select-dropdown-color, #0d0d0d);
   border: 1px solid rgba(185, 3, 226, 0.3);
   border-radius: 8px;
@@ -25,16 +25,16 @@
   --dyvix-select-active-bg: #8b5cf6;
   --dyvix-select-active-text: #ffffff;
 }
-.dyvix-select-lens .dyvix-select-dropdown-lens li {
+.dyvix-select-singularity .dyvix-select-dropdown-singularity li {
   background: transparent;
   color: rgba(255, 255, 255, 0.85);
   border-bottom: 1px solid rgba(185, 3, 226, 0.1);
 }
-.dyvix-select-lens .dyvix-select-dropdown-lens li:hover {
+.dyvix-select-singularity .dyvix-select-dropdown-singularity li:hover {
   background: rgba(185, 3, 226, 0.15);
   color: white;
 }
-.dyvix-select-lens .dyvix-select-dropdown-lens::-webkit-scrollbar-thumb {
+.dyvix-select-singularity .dyvix-select-dropdown-singularity::-webkit-scrollbar-thumb {
   background: rgba(185, 3, 226, 0.6);
 }
 /* Industrial Theme */

--- a/src/components/select/dependencies/themes.json
+++ b/src/components/select/dependencies/themes.json
@@ -1,9 +1,9 @@
 [
   {
     "theme": "Singularity",
-    "class": "dyvix-select-lens",
-    "input-class": "dyvix-select-input-lens",
-    "dropdown-class": "dyvix-select-dropdown-lens",
+    "class": "dyvix-select-singularity",
+    "input-class": "dyvix-select-input-singularity",
+    "dropdown-class": "dyvix-select-dropdown-singularity",
     "default-animation": "bubble"
   },
   {


### PR DESCRIPTION
## Summary

This PR standardizes the Singularity theme naming across components by replacing the legacy `lens` naming with `singularity`.

### Changes
- Renamed `dyvix-*-lens` classes to `dyvix-*-singularity`.
- Updated corresponding CSS selectors.
- Removed the temporary hardcoded workaround from `dev-engine/scripts/check-themes.js`.

Fixes #353