### PR TITLE
docs: add Crimson to the themes list

### DIFF
--- a/docs/guide/themes.md
+++ b/docs/guide/themes.md
@@ -24,4 +24,5 @@ Dyvix provides a wide range of themes. You can trigger these by passing the stri
 - `DYVIX_GLOBAL_THEME.OCEAN`: `'Ocean'`
 - `DYVIX_GLOBAL_THEME.FOREST`: `'Forest'`
 - `DYVIX_GLOBAL_THEME.MIDNIGHT`: `'Midnight'`
+- `DYVIX_GLOBAL_THEME.CRIMSON`: `'Crimson'`
 - `DYVIX_GLOBAL_THEME.OBSIDIAN`: `'Obsidian'`


### PR DESCRIPTION
## 📝 Description

Added the **Crimson** theme to the themes documentation to keep it synchronized with the exported theme constants.

## 🔗 Related Issue

Closes #364

## ✅ Changes Made

- Added `DYVIX_GLOBAL_THEME.CRIMSON` to the list of available themes.
- Maintained the existing ordering and formatting of the documentation.

## 🧪 Testing

- Verified the documentation entry matches the existing theme format.
- Confirmed the themes list now includes the Crimson theme.