### PR TITLE
docs: sync DyvixTable JSDoc with supported themes and animations

### DIFF
--- a/src/components/table/table.jsx
+++ b/src/components/table/table.jsx
@@ -15,11 +15,11 @@ import Version from '../../../package.json';
  * @param {Object} props
  * @param {React.ReactNode} [props.children] - Composable mode content (DyvixTableHeader, DyvixTableBody, etc.)
  * @param {string} [props.className] - Additional className
- * @param {string} [props.animation] - Animation name, defaults to 'fade'
- * @param {('Singularity'|'Crimson')} [props.theme] - Table theme
+ * @param {('fade'|'bubble'|'zoom'|'unfold'|'glitch'|'pulse'|'aurora'|'drop'|'flip'|'glide'|'drift'|'float'|'swing')} [props.animation] - Animation name, defaults to 'fade'
+ * @param {('Singularity'|'Industrial'|'Ember'|'Frost'|'Blade'|'Neon'|'Aurora'|'Sunset'|'Ocean'|'Forest'|'Midnight'|'Crimson'|'Obsidian')} [props.theme] - Table theme
  * @param {string} [props.background] - Custom background color
  * @param {string} [props.color] - Custom text color
- * @param {Array<{key: string, label: string}>} [props.columns] - Column definitions for config-driven mode
+ * @param {Array<{key: string, label: string, sortable?: boolean}>} [props.columns] - Column definitions for config-driven mode
  * @param {Array<Object>} [props.data] - Row data for config-driven mode, keys must match column keys
  * @param {Object} [props.style] - Inline style overrides
  */


### PR DESCRIPTION
Closes #369 

## Description
This PR synchronizes the `DyvixTable JSDoc` documentation with the current supported themes and animations defined in `constants.js`.

## Changes

1. Documentation: Updated the JSDoc block for `DyvixTable `in both` src`/ and `devbench`/ to reflect all 13 supported themes and 13 animation presets.
3. Sync: Ensured documentation consistency between the component source and the test/development environment.
4. Developer Experience: Improved IDE autocompletion for theme and animation props by explicitly listing available options in the JSDoc.

## Verification

- [x] Verified themes against `themes.css` selectors.

- [x] Verified animation types against `DYVIX_GLOBAL_ANIMATION` constants.

- [x] Ensured documentation format matches the library's coding standards.