### PR TITLE
[Feature] Add Obsidian file theme

### DIFF
--- a/src/components/file/dependencies/style/themes.css
+++ b/src/components/file/dependencies/style/themes.css
@@ -378,3 +378,35 @@
 .dyvix-file-crimson:hover p {
   color: #ffffff;
 }
+
+.dyvix-file-obsidian {
+  background: radial-gradient(
+    circle at top,
+    #2a2a2a 0%,
+    #151515 45%,
+    #050505 100%
+  );
+  border: 2px solid rgba(160, 130, 255, 0.4);
+  border-radius: 1.25rem;
+  box-shadow:
+    inset 0 0 40px rgba(255, 255, 255, 0.04),
+    0 0 40px rgba(120, 90, 255, 0.18);
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+.dyvix-file-obsidian p {
+  color: #e5edff;
+  transition: color 0.2s ease-in-out;
+}
+.dyvix-file-obsidian:hover {
+  transform: scale(1.02);
+  box-shadow:
+    inset 0 0 30px rgba(255, 255, 255, 0.05),
+    0 0 65px rgba(130, 100, 255, 0.25);
+  border-color: rgba(180, 150, 255, 0.7);
+}
+.dyvix-file-obsidian:hover p {
+  color: #ffffff;
+}

--- a/src/components/file/dependencies/themes.json
+++ b/src/components/file/dependencies/themes.json
@@ -58,5 +58,10 @@
     "theme": "Crimson",
     "class": "dyvix-file-crimson",
     "default-animation": "float"
+  },
+  {
+    "theme": "Obsidian",
+    "class": "dyvix-file-obsidian",
+    "default-animation": "fade"
   }
 ]


### PR DESCRIPTION
Closes #346

Adds the Obsidian theme to the file component's theme registry, following the same pattern already established in `themeRegistry/themes.json` and the modal component's Obsidian theme.

Changes:
- Added Obsidian entry to `src/components/file/dependencies/themes.json`
- Added `.dyvix-file-obsidian` styles to `src/components/file/dependencies/style/themes.css`, matching the dark charcoal + purple glow visual identity used in the modal theme

Tested locally via devbench (`npm run dev`) — verified the theme renders correctly and hover states work as expected.