### PR TITLE
feat(select): add Sunset theme support

### DIFF
--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -197,3 +197,68 @@
 .dyvix-select-neon .dyvix-select-dropdown-neon::-webkit-scrollbar-thumb {
   background: rgba(252, 46, 255, 0.6);
 }
+/* Sunset Theme */
+
+.dyvix-select-sunset .dyvix-select-input-sunset {
+  background: linear-gradient(
+    135deg,
+    #1a0a00 0%,
+    #3d1a00 40%,
+    #6b2d00 70%,
+    #8b3a00 100%
+  );
+  border: 1px solid rgba(255, 198, 15, 0.1);
+  border-bottom: 5px solid #a84600;
+  border-radius: 20px;
+  color: #ffffff;
+  box-shadow: 0px 15px 38px -10px rgba(255, 198, 15, 0.88);
+  transition:
+    transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.3s ease-in-out,
+    border-radius 0.2s ease-in-out;
+}
+
+.dyvix-select-sunset .dyvix-select-input-sunset:hover {
+  transform: translateY(2px);
+  box-shadow: 0 20px 50px -10px rgba(255, 198, 15, 0.6);
+  border-radius: 15px;
+}
+
+.dyvix-select-sunset .dyvix-select-input-sunset:focus {
+  outline: none;
+}
+
+.dyvix-select-sunset .dyvix-select-input-sunset::placeholder {
+  color: rgba(255, 220, 150, 0.7);
+}
+
+.dyvix-select-sunset .dyvix-select-dropdown-sunset {
+  background: var(
+    --dyvix-select-dropdown-color,
+    linear-gradient(
+      135deg,
+      #1a0a00 0%,
+      #3d1a00 40%,
+      #6b2d00 70%,
+      #8b3a00 100%
+    )
+  );
+  border: 1px solid rgba(255, 198, 15, 0.2);
+  border-radius: 12px;
+  box-shadow: 0px 15px 38px -10px rgba(255, 198, 15, 0.5);
+
+  --dyvix-select-active-bg: #a84600;
+  --dyvix-select-active-text: #ffffff;
+}
+
+.dyvix-select-sunset .dyvix-select-dropdown-sunset li {
+  color: #ffffff;
+}
+
+.dyvix-select-sunset .dyvix-select-dropdown-sunset li:hover {
+  background: rgba(255, 198, 15, 0.15);
+}
+
+.dyvix-select-sunset .dyvix-select-dropdown-sunset::-webkit-scrollbar-thumb {
+  background: rgba(255, 198, 15, 0.6);
+}

--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -221,7 +221,7 @@
 .dyvix-select-sunset .dyvix-select-input-sunset:hover {
   transform: translateY(2px);
   box-shadow: 0px 10px 30px -10px rgba(255, 198, 15, 0.7);
-  border-radius: 15px;
+  border-radius: 17px;
 }
 
 .dyvix-select-sunset .dyvix-select-input-sunset:focus {

--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -235,13 +235,7 @@
 .dyvix-select-sunset .dyvix-select-dropdown-sunset {
   background: var(
     --dyvix-select-dropdown-color,
-    linear-gradient(
-      135deg,
-      #1a0a00 0%,
-      #3d1a00 40%,
-      #6b2d00 70%,
-      #8b3a00 100%
-    )
+    linear-gradient(135deg, #1a0a00 0%, #3d1a00 40%, #6b2d00 70%, #8b3a00 100%)
   );
   border: 1px solid rgba(255, 198, 15, 0.2);
   border-radius: 12px;

--- a/src/components/select/dependencies/style/themes.css
+++ b/src/components/select/dependencies/style/themes.css
@@ -220,7 +220,7 @@
 
 .dyvix-select-sunset .dyvix-select-input-sunset:hover {
   transform: translateY(2px);
-  box-shadow: 0 20px 50px -10px rgba(255, 198, 15, 0.6);
+  box-shadow: 0px 10px 30px -10px rgba(255, 198, 15, 0.7);
   border-radius: 15px;
 }
 
@@ -253,6 +253,7 @@
 
 .dyvix-select-sunset .dyvix-select-dropdown-sunset li {
   color: #ffffff;
+  transition: background 0.2s ease;
 }
 
 .dyvix-select-sunset .dyvix-select-dropdown-sunset li:hover {

--- a/src/components/select/dependencies/themes.json
+++ b/src/components/select/dependencies/themes.json
@@ -33,5 +33,12 @@
     "input-class": "dyvix-select-input-neon",
     "dropdown-class": "dyvix-select-dropdown-neon",
     "default-animation": "pulse"
-  }
+  },
+  {
+  "theme": "Sunset",
+  "class": "dyvix-select-sunset",
+  "input-class": "dyvix-select-input-sunset",
+  "dropdown-class": "dyvix-select-dropdown-sunset",
+  "default-animation": "drop"
+}
 ]

--- a/src/components/select/dependencies/themes.json
+++ b/src/components/select/dependencies/themes.json
@@ -35,10 +35,10 @@
     "default-animation": "pulse"
   },
   {
-  "theme": "Sunset",
-  "class": "dyvix-select-sunset",
-  "input-class": "dyvix-select-input-sunset",
-  "dropdown-class": "dyvix-select-dropdown-sunset",
-  "default-animation": "drop"
-}
+    "theme": "Sunset",
+    "class": "dyvix-select-sunset",
+    "input-class": "dyvix-select-input-sunset",
+    "dropdown-class": "dyvix-select-dropdown-sunset",
+    "default-animation": "drop"
+  }
 ]


### PR DESCRIPTION
## Summary

Added support for the **Sunset** global theme to the Select component.

### Changes
- Added the `Sunset` theme entry to `src/components/select/dependencies/themes.json`
- Added the corresponding Sunset styles to `src/components/select/dependencies/style/themes.css`
- Verified the theme locally using the Select devbench

### Testing
- Ran `npm install`
- Ran `npm run dev`
- Verified that the Select input and dropdown correctly render with the Sunset theme.

Fixes #366