### PR TITLE
docs: add missing SLIDERIGHT, SPIRAL, BOUNCE to animations list

### DIFF
--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -26,3 +26,6 @@ Dyvix provides a wide range of smooth animations. You can trigger these by passi
 - `DYVIX_GLOBAL_ANIMATION.DRIFT`: `'drift'`
 - `DYVIX_GLOBAL_ANIMATION.FLOAT`: `'float'`
 - `DYVIX_GLOBAL_ANIMATION.SWING`: `'swing'`
+- `DYVIX_GLOBAL_ANIMATION.SLIDERIGHT`: `'slideRight'`
+- `DYVIX_GLOBAL_ANIMATION.SPIRAL`: `'spiral'`
+- `DYVIX_GLOBAL_ANIMATION.BOUNCE`: `'bounce'`


### PR DESCRIPTION
## Summary
The global animations list in `docs/guide/animations.md` was outdated and missing three animations that already exist in `DYVIX_GLOBAL_ANIMATION` (defined in `src/constants.js`): `SLIDERIGHT` (`'slideRight'`), `SPIRAL` (`'spiral'`), and `BOUNCE` (`'bounce'`).

## Change
Added the three missing entries to the "Available Animations" list in `docs/guide/animations.md`, following the exact same formatting as the existing entries.

## Testing
Verified by diffing the animation keys exported from `src/constants.js` against the entries listed in `docs/guide/animations.md` — after this change, the two are in sync (16 animations listed, matching the 16 keys in `DYVIX_GLOBAL_ANIMATION`).

Closes #426