### PR TITLE
docs: add missing animations to the global animations list

### DIFF
--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -26,3 +26,6 @@ Dyvix provides a wide range of smooth animations. You can trigger these by passi
 - `DYVIX_GLOBAL_ANIMATION.DRIFT`: `'drift'`
 - `DYVIX_GLOBAL_ANIMATION.FLOAT`: `'float'`
 - `DYVIX_GLOBAL_ANIMATION.SWING`: `'swing'`
+- `DYVIX_GLOBAL_ANIMATION.SLIDERIGHT`: `'slideRight'`
+- `DYVIX_GLOBAL_ANIMATION.SPIRAL`: `'spiral'`
+- `DYVIX_GLOBAL_ANIMATION.BOUNCE`: `'bounce'`


### PR DESCRIPTION
## Summary

Fixes #426

The **Available Animations** list in `docs/guide/animations.md` was missing three animations that exist in `DYVIX_GLOBAL_ANIMATION` (`src/constants.js`):

- `DYVIX_GLOBAL_ANIMATION.SLIDERIGHT`: `'slideRight'`
- `DYVIX_GLOBAL_ANIMATION.SPIRAL`: `'spiral'`
- `DYVIX_GLOBAL_ANIMATION.BOUNCE`: `'bounce'`

This PR appends them to the list, keeping the same format and the same order as the constants file / `src/components/animations.json`.

## Validation

- Verified against `DYVIX_GLOBAL_ANIMATION` in `src/constants.js` — the docs list now covers all 16 entries.
- `npm run docs:build` passes locally (VitePress build completes without errors).