### PR TITLE
docs: add toast component playground

### DIFF
--- a/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
@@ -94,7 +94,9 @@ export default function ToastPlayground() {
             className={'toast-btn'}
             style={{ backgroundColor: '#22c55e' }}
             onClick={() => dyvixToast.success('Operation completed')}
-          ></button>
+          >
+            Success toast
+          </button>
           <button
             className={'toast-btn'}
             style={{ backgroundColor: '#ef4444' }}

--- a/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
@@ -82,17 +82,35 @@ export default function ToastPlayground() {
           animation={animation}
           segments={segments}
         />
-        <div style={{display: 'flex', gap: '5px', flexWrap: 'wrap', padding: '16px 0'}}>
-          <button className={'toast-btn'} style={{ backgroundColor: '#22c55e'}} onClick={() => dyvixToast.success('Operation completed')}>
-            Success toast
+        <div
+          style={{
+            display: 'flex',
+            gap: '5px',
+            flexWrap: 'wrap',
+            padding: '16px 0'
+          }}
+        >
+          <button
+            className={'toast-btn'}
+            style={{ backgroundColor: '#22c55e' }}
+            onClick={() => dyvixToast.success('Operation completed')}
+          >
           </button>
           <button className={'toast-btn'} style={{ backgroundColor: '#ef4444'}} onClick={() => dyvixToast.error('Something went wrong')}>
             Error toast
           </button>
-          <button className={'toast-btn'} style={{ backgroundColor: '#eab308'}} onClick={() => dyvixToast.warning('Please review this action')}>
+          <button
+            className={'toast-btn'}
+            style={{ backgroundColor: '#ef4444' }}
+            onClick={() => dyvixToast.error('Something went wrong')}
+          >
             Warning toast
           </button>
-          <button className={'toast-btn'} style={{ backgroundColor: '#3b82f6'}} onClick={() => dyvixToast.info('Here is an update')}>
+          <button
+            className={'toast-btn'}
+            style={{ backgroundColor: '#eab308' }}
+            onClick={() => dyvixToast.warning('Please review this action')}
+          >
             Info toast
           </button>
         </div>

--- a/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
@@ -94,9 +94,12 @@ export default function ToastPlayground() {
             className={'toast-btn'}
             style={{ backgroundColor: '#22c55e' }}
             onClick={() => dyvixToast.success('Operation completed')}
+          ></button>
+          <button
+            className={'toast-btn'}
+            style={{ backgroundColor: '#ef4444' }}
+            onClick={() => dyvixToast.error('Something went wrong')}
           >
-          </button>
-          <button className={'toast-btn'} style={{ backgroundColor: '#ef4444'}} onClick={() => dyvixToast.error('Something went wrong')}>
             Error toast
           </button>
           <button

--- a/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
@@ -1,0 +1,100 @@
+import {
+  DyvixToastContainer,
+  dyvixToast,
+  DYVIX_GLOBAL_ANIMATION
+} from 'dyvix-ui';
+import Wrapper from '../Wrapper';
+import React from 'react';
+
+const TOAST_POSITIONS = {
+  TOP_LEFT: 'top-left',
+  TOP_RIGHT: 'top-right',
+  TOP_CENTER: 'top-center',
+  BOTTOM_LEFT: 'bottom-left',
+  BOTTOM_RIGHT: 'bottom-right',
+  BOTTOM_CENTER: 'bottom-center'
+};
+
+const TOAST_DURATIONS = {
+  SHORT: 2000,
+  DEFAULT: 5000,
+  LONG: 8000
+};
+
+const TOAST_SEGMENTS = {
+  ONE: 1,
+  THREE: 3,
+  FIVE: 5,
+  TEN: 10
+};
+
+export default function ToastPlayground() {
+  const [config, setConfig] = React.useState([
+    {
+      utility: 'position',
+      type: 'select',
+      options: TOAST_POSITIONS,
+      current: TOAST_POSITIONS.TOP_RIGHT,
+      format: 'string',
+      allowNull: false
+    },
+    {
+      utility: 'duration',
+      type: 'select',
+      options: TOAST_DURATIONS,
+      current: TOAST_DURATIONS.DEFAULT,
+      format: 'number',
+      allowNull: false
+    },
+    {
+      utility: 'animation',
+      type: 'select',
+      options: DYVIX_GLOBAL_ANIMATION,
+      current: DYVIX_GLOBAL_ANIMATION.ZOOM,
+      format: 'string',
+      allowNull: false
+    },
+    {
+      utility: 'segments',
+      type: 'select',
+      options: TOAST_SEGMENTS,
+      current: TOAST_SEGMENTS.THREE,
+      format: 'number',
+      allowNull: false
+    }
+  ]);
+
+  const position = config.find((e) => e.utility === 'position').current;
+  const duration = Number(config.find((e) => e.utility === 'duration').current);
+  const animation = config.find((e) => e.utility === 'animation').current;
+  const segments = Number(config.find((e) => e.utility === 'segments').current);
+
+  return (
+    <Wrapper
+      componentConfig={config}
+      componentCallback={setConfig}
+      tag={'DyvixToastContainer'}
+    >
+      <div>
+        <DyvixToastContainer
+          position={position}
+          duration={duration}
+          animation={animation}
+          segments={segments}
+        />
+        <button onClick={() => dyvixToast.success('Operation completed')}>
+          Success toast
+        </button>
+        <button onClick={() => dyvixToast.error('Something went wrong')}>
+          Error toast
+        </button>
+        <button onClick={() => dyvixToast.warning('Please review this action')}>
+          Warning toast
+        </button>
+        <button onClick={() => dyvixToast.info('Here is an update')}>
+          Info toast
+        </button>
+      </div>
+    </Wrapper>
+  );
+}

--- a/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
@@ -106,15 +106,15 @@ export default function ToastPlayground() {
           </button>
           <button
             className={'toast-btn'}
-            style={{ backgroundColor: '#ef4444' }}
-            onClick={() => dyvixToast.error('Something went wrong')}
+            style={{ backgroundColor: '#eab308' }}
+            onClick={() => dyvixToast.warning('Something went wrong')}
           >
             Warning toast
           </button>
           <button
             className={'toast-btn'}
-            style={{ backgroundColor: '#eab308' }}
-            onClick={() => dyvixToast.warning('Please review this action')}
+            style={{ backgroundColor: 'blue' }}
+            onClick={() => dyvixToast.info('Please review this action')}
           >
             Info toast
           </button>

--- a/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.jsx
@@ -82,18 +82,20 @@ export default function ToastPlayground() {
           animation={animation}
           segments={segments}
         />
-        <button onClick={() => dyvixToast.success('Operation completed')}>
-          Success toast
-        </button>
-        <button onClick={() => dyvixToast.error('Something went wrong')}>
-          Error toast
-        </button>
-        <button onClick={() => dyvixToast.warning('Please review this action')}>
-          Warning toast
-        </button>
-        <button onClick={() => dyvixToast.info('Here is an update')}>
-          Info toast
-        </button>
+        <div style={{display: 'flex', gap: '5px', flexWrap: 'wrap', padding: '16px 0'}}>
+          <button className={'toast-btn'} style={{ backgroundColor: '#22c55e'}} onClick={() => dyvixToast.success('Operation completed')}>
+            Success toast
+          </button>
+          <button className={'toast-btn'} style={{ backgroundColor: '#ef4444'}} onClick={() => dyvixToast.error('Something went wrong')}>
+            Error toast
+          </button>
+          <button className={'toast-btn'} style={{ backgroundColor: '#eab308'}} onClick={() => dyvixToast.warning('Please review this action')}>
+            Warning toast
+          </button>
+          <button className={'toast-btn'} style={{ backgroundColor: '#3b82f6'}} onClick={() => dyvixToast.info('Here is an update')}>
+            Info toast
+          </button>
+        </div>
       </div>
     </Wrapper>
   );

--- a/docs/.vitepress/theme/components/toast/ToastPlayground.vue
+++ b/docs/.vitepress/theme/components/toast/ToastPlayground.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ToastPlayground from './ToastPlayground';
+
+const container = ref(null);
+let root;
+
+onMounted(() => {
+  root = ReactDOM.createRoot(container.value);
+  root.render(React.createElement(ToastPlayground));
+});
+
+onUnmounted(() => root?.unmount());
+</script>
+
+<template>
+  <div ref="container"></div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -41,3 +41,8 @@
   -moz-box-shadow: 0px 0px 300px 0px rgba(9, 232, 165, 0.39);
   box-shadow: 0px 0px 300px 0px rgba(9, 232, 165, 0.39);
 }
+
+.toast-btn {
+  padding: 6px 12px;
+  border-radius: 4px;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,6 +5,7 @@ import InputPlayground from './components/input/InputPlayground.vue';
 import ModalPlayground from './components/modal/ModalPlayground.vue';
 import SelectPlayground from './components/select/SelectPlayground.vue';
 import LabelPlayground from './components/label/LabelPlayground.vue';
+import ToastPlayground from './components/toast/ToastPlayground.vue';
 import './custom.css';
 
 export default {
@@ -16,5 +17,6 @@ export default {
     app.component('ModalPlayground', ModalPlayground);
     app.component('SelectPlayground', SelectPlayground);
     app.component('LabelPlayground', LabelPlayground);
+    app.component('ToastPlayground', ToastPlayground);
   }
 };

--- a/docs/components/toast/toast.md
+++ b/docs/components/toast/toast.md
@@ -52,3 +52,9 @@ function ToastExample() {
   );
 }
 ```
+
+## Try it
+
+Use the controls to configure the container, then trigger a toast to preview each notification type.
+
+<ToastPlayground />


### PR DESCRIPTION
## Summary
- add an interactive playground for all toast container settings
- add live triggers for success, error, warning, and info notifications
- register and embed the playground in the Toast documentation

## Validation
- `npm run build`
- `npm run docs:build`
- Prettier check for changed documentation files

Fixes younisdev/dyvix-ui#451

Contributed by @ANONYMOUSZED-beep.