### PR TITLE
feat(nav): add Ember theme

### DIFF
--- a/src/components/nav/dependencies/style/themes.css
+++ b/src/components/nav/dependencies/style/themes.css
@@ -46,3 +46,60 @@
   background-color: #b903e2;
   box-shadow: 0 0 8px #b903e2;
 }
+
+.dyvix-nav-ember {
+  border-radius: 10px;
+  background: var(--dyvix-nav-bg, #0f0a08);
+  border-bottom: var(--dyvix-nav-border, #ff4500) 3px solid;
+  box-shadow:
+    0px 17px 12px -9px rgba(255, 69, 0, 0.73),
+    0px 0px 30px -10px rgba(255, 69, 0, 0.3);
+  -webkit-box-shadow:
+    0px 17px 12px -9px rgba(255, 69, 0, 0.73),
+    0px 0px 30px -10px rgba(255, 69, 0, 0.3);
+  -moz-box-shadow:
+    0px 17px 12px -9px rgba(255, 69, 0, 0.73),
+    0px 0px 30px -10px rgba(255, 69, 0, 0.3);
+  transition:
+    transform 0.5s ease-in-out,
+    border-bottom 0.4s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    -webkit-box-shadow 0.3s ease-in-out,
+    -moz-box-shadow 0.3s ease-in-out;
+}
+
+.dyvix-nav-ember:hover {
+  border-bottom: #ff6b00 3.1px solid;
+  transform: scale(1.002);
+  box-shadow:
+    0px 17px 20px -9px rgba(255, 69, 0, 0.9),
+    0px 0px 40px -5px rgba(255, 69, 0, 0.5);
+  -webkit-box-shadow:
+    0px 17px 20px -9px rgba(255, 69, 0, 0.9),
+    0px 0px 40px -5px rgba(255, 69, 0, 0.5);
+  -moz-box-shadow:
+    0px 17px 20px -9px rgba(255, 69, 0, 0.9),
+    0px 0px 40px -5px rgba(255, 69, 0, 0.5);
+}
+
+.dyvix-nav-ember .dyvix-nav-brand {
+  color: #ffffff;
+  text-shadow: 0 0 12px #ff4500;
+}
+
+.dyvix-nav-ember .dyvix-nav-brand:hover {
+  color: var(--dyvix-nav-brand-hover, #ffb27a);
+}
+
+.dyvix-nav-ember .dyvix-nav-link {
+  color: var(--dyvix-nav-link-color, rgba(255, 255, 255, 0.65));
+}
+
+.dyvix-nav-ember .dyvix-nav-link:hover {
+  color: var(--dyvix-nav-link-hover, #ffb27a);
+}
+
+.dyvix-nav-ember .dyvix-nav-link::after {
+  background-color: #ff4500;
+  box-shadow: 0 0 8px #ff4500;
+}


### PR DESCRIPTION
## Summary
Ports the global **Ember** theme to the navigation component, as requested in #450. Adds the `.dyvix-nav-ember` classes to [`src/components/nav/dependencies/style/themes.css`](src/components/nav/dependencies/style/themes.css). No other files are changed.

Closes #450

## What was added
Seven rules, mirroring the structure of the existing `.dyvix-nav-singularity` theme:
- `.dyvix-nav-ember` — base container (background, bottom-edge accent, glow, transitions)
- `.dyvix-nav-ember:hover`
- `.dyvix-nav-ember .dyvix-nav-brand` / `:hover`
- `.dyvix-nav-ember .dyvix-nav-link` / `:hover`
- `.dyvix-nav-ember .dyvix-nav-link::after` — the underline accent

## How the values were chosen
To keep Ember consistent across components, the colors, shadows and transitions were taken directly from the existing **modal** Ember theme (`.dyvix-modal-ember` in `src/components/modal/dependencies/style/themes.css`):
- Background `#0f0a08`, accent `#ff4500`, hover accent `#ff6b00`
- `box-shadow` (base + hover, incl. `-webkit-`/`-moz-`) and the `transition` list are copied verbatim
- `border-radius: 10px` matches the Ember box shape used by the other components (button/file/input/table)

Themeable values are wrapped in nav's existing CSS variables (`--dyvix-nav-bg`, `--dyvix-nav-border`, `--dyvix-nav-brand-hover`, `--dyvix-nav-link-color`, `--dyvix-nav-link-hover`) so consumers can still override them.

The brand/link **hover tint** (`#ffb27a`) is the one value with no direct source in the modal theme — it's a lightened Ember shade, chosen by analogy to how Singularity uses a lightened `#e9b8f7`.

`color` and `font-family` are intentionally omitted from the base rule because modal-ember doesn't define them either, and nav's base `.dyvix-nav` already provides a readable text color.

## Testing
- `node dev-engine/scripts/check-themes.js nav` — Ember is no longer reported as missing.
- Previewed in `devbench` with `theme="Ember"`: verified the base look, hover states (accent brightening, link underline, brand/link tint)