### PR TITLE
feat(nav): add Industrial navigation theme

### DIFF
--- a/devbench/src/component/navigation.jsx
+++ b/devbench/src/component/navigation.jsx
@@ -4,7 +4,7 @@ import { DYVIX_GLOBAL_ANIMATION, DYVIX_GLOBAL_THEME } from '../../../src';
 export function NavTest() {
   return (
     <>
-      <DyvixNav animation="bubble" theme="Singularity">
+      <DyvixNav animation="bubble" theme="Industrial">
         <DyvixNav.Brand href="/">GOO</DyvixNav.Brand>
 
         <DyvixNav.Menu>
@@ -24,7 +24,7 @@ export function NavTest() {
         ]}
         animation="fade"
         microanimation="pulse"
-        theme={'Singularity'}
+        theme={'Industrial'}
       />
     </>
   );

--- a/src/components/nav/dependencies/style/themes.css
+++ b/src/components/nav/dependencies/style/themes.css
@@ -47,6 +47,51 @@
   box-shadow: 0 0 8px #b903e2;
 }
 
+.dyvix-nav-industrial {
+  font-family: 'Geist';
+  border: 2px solid #374151;
+  border-radius: 10px;
+  background-color: #0a1429;
+  padding: 0.5rem;
+  transition:
+    box-shadow ease-in-out 0.6s,
+    border-color ease-in-out 0.3s,
+    background-color ease-in-out 0.2s,
+    transform ease-in-out 0.1s;
+}
+
+.dyvix-nav-industrial:hover {
+  border-color: #6a6a6a;
+  box-shadow:
+    inset 0 0 30px rgba(106, 106, 106, 0.1),
+    0 0 20px rgba(106, 106, 106, 0.15);
+  background-color: #101f39;
+  transform: scale(1.01);
+  border-radius: 11px;
+}
+
+.dyvix-nav-industrial .dyvix-nav-brand {
+  color: #f5f7fa;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.12);
+}
+
+.dyvix-nav-industrial .dyvix-nav-brand:hover {
+  color: var(--dyvix-nav-brand-hover, #d3d8e6);
+}
+
+.dyvix-nav-industrial .dyvix-nav-link {
+  color: var(--dyvix-nav-link-color, rgba(226, 232, 240, 0.8));
+}
+
+.dyvix-nav-industrial .dyvix-nav-link:hover {
+  color: var(--dyvix-nav-link-hover, #f8fafc);
+}
+
+.dyvix-nav-industrial .dyvix-nav-link::after {
+  background-color: #6a6a6a;
+  box-shadow: 0 0 8px rgba(106, 106, 106, 0.25);
+}
+
 .dyvix-nav-ember {
   border-radius: 10px;
   background: var(--dyvix-nav-bg, #0f0a08);

--- a/src/components/nav/dependencies/style/themes.css
+++ b/src/components/nav/dependencies/style/themes.css
@@ -49,15 +49,16 @@
 
 .dyvix-nav-industrial {
   font-family: 'Geist';
-  border: 2px solid #374151;
+  border: 6px solid var(--dyvix-nav-border, #374151);
   border-radius: 10px;
-  background-color: #0a1429;
+  background-color: var(--dyvix-nav-bg, #0a1429);
   padding: 0.5rem;
   transition:
     box-shadow ease-in-out 0.6s,
     border-color ease-in-out 0.3s,
     background-color ease-in-out 0.2s,
-    transform ease-in-out 0.1s;
+    transform ease-in-out 0.1s,
+    border-radius ease-in-out 0.3s;
 }
 
 .dyvix-nav-industrial:hover {


### PR DESCRIPTION
This PR adds the Industrial theme for the Navigation component.

### Changes
- Added `dyvix-nav-industrial` styles to the navigation theme CSS.
- Updated the devbench navigation demo to preview the Industrial theme.

Closes #438 