### PR TITLE
feat(nav): add Frost theme

### DIFF
--- a/src/components/nav/dependencies/style/themes.css
+++ b/src/components/nav/dependencies/style/themes.css
@@ -149,3 +149,52 @@
   background-color: #ff4500;
   box-shadow: 0 0 8px #ff4500;
 }
+
+.dyvix-nav-frost {
+  background: var(--dyvix-nav-bg, #ffffff1a);
+  border: 5px groove var(--dyvix-nav-border, #ffffff40);
+  border-radius: 20px;
+  backdrop-filter: blur(50px);
+  -webkit-backdrop-filter: blur(50px);
+  box-shadow: -6px 2px 51px -7px rgba(213, 255, 248, 1) inset;
+  -webkit-box-shadow: -6px 2px 51px -7px rgba(213, 255, 248, 1) inset;
+  -moz-box-shadow: -6px 2px 51px -7px rgba(213, 255, 248, 1) inset;
+  transition:
+    transform 0.5s ease-in-out,
+    box-shadow 0.3s ease-in-out,
+    -webkit-box-shadow 0.3s ease-in-out,
+    -moz-box-shadow 0.3s ease-in-out,
+    border 0.2s ease-in-out;
+}
+
+.dyvix-nav-frost:hover {
+  border: 5px groove #f8f8f840;
+  transform: scale(1.01);
+  box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
+  -webkit-box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
+  -moz-box-shadow: -6px 2px 51px -23px rgba(213, 255, 248, 1) inset;
+}
+
+.dyvix-nav-frost .dyvix-nav-brand {
+  color: rgba(213, 255, 248, 1);
+  text-shadow:
+    0 0 8px rgba(213, 255, 248, 0.65),
+    0 0 20px rgba(248, 248, 248, 0.25);
+}
+
+.dyvix-nav-frost .dyvix-nav-brand:hover {
+  color: var(--dyvix-nav-brand-hover, #f8f8f8);
+}
+
+.dyvix-nav-frost .dyvix-nav-link {
+  color: var(--dyvix-nav-link-color, rgba(213, 255, 248, 0.65));
+}
+
+.dyvix-nav-frost .dyvix-nav-link:hover {
+  color: var(--dyvix-nav-link-hover, #f8f8f8);
+}
+
+.dyvix-nav-frost .dyvix-nav-link::after {
+  background-color: rgba(213, 255, 248, 1);
+  box-shadow: 0 0 8px rgba(213, 255, 248, 0.65);
+}


### PR DESCRIPTION
## Summary
Ports the global **Frost** theme to the navigation component, as requested in #455. Adds the `.dyvix-nav-frost` classes to [`src/components/nav/dependencies/style/themes.css`](src/components/nav/dependencies/style/themes.css). No other files are changed.

Closes #455

## What was added
- `.dyvix-nav-frost` — base container (frosted background, groove border, backdrop blur, inset glow, transitions)
- `.dyvix-nav-frost:hover`
- `.dyvix-nav-frost .dyvix-nav-brand` / `:hover`
- `.dyvix-nav-frost .dyvix-nav-link` / `:hover`
- `.dyvix-nav-frost .dyvix-nav-link::after` — the underline accent

## Two nav-specific adjustments
**1. Added `-webkit-backdrop-filter: blur(50px)`** — not present in modal-frost. The nav base style sets both `backdrop-filter` and `-webkit-backdrop-filter` ([`style.css`](src/components/nav/dependencies/style/style.css)), so without overriding the prefixed property, Safari and iOS browsers would keep the base `blur(12px)` and render Frost without its glass effect.

**2. Hover keeps the border width at `5px` and changes only its color**, where modal-frost goes `5px → 8px`. `.dyvix-nav-wrapper` is `position: sticky` and therefore stays in normal flow, so growing the border increases the nav's height and pushes the rest of the page down on every hover. This follows `.dyvix-nav-singularity` (which keeps `2px` in both states and changes only the color) and `.dyvix-nav-industrial` (which changes `border-color` and `border-radius`, never the width). Hover feedback is still provided by the border brightening, the tightening inset glow, and `transform: scale(1.01)` — all of which are layout-free.

## Testing
- `node dev-engine/scripts/check-themes.js nav` — Frost is no longer reported as missing.
- `npx prettier --check` passes on the changed file.
- Previewed in `devbench` with `theme="Frost" animation="unfold"`: verified the base look, hover states (border brightening, inset glow, brand/link tint, underline), that the `unfold` entrance animation plays correctly alongside the theme, and that hovering no longer shifts the layout of elements below the navbar.
- Rebased onto latest `main` (includes the recently merged Industrial nav theme); merges cleanly.

Fixes #455