### PR TITLE
release(scope): v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dyvix-ui",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dyvix-ui",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "workspaces": [
         "devbench"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dyvix-ui",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Dyvix is an open source, modern, config-driven, animated component UI library. Beautiful by default, customizable by design.",
   "type": "module",
   "sideEffects": [


### PR DESCRIPTION
Pump to 0.5.0 instead of 0.4.2 given the scope of the release.