### PR TITLE
docs(modal): document dynamic positioning

### DIFF
--- a/docs/components/modal/modal.md
+++ b/docs/components/modal/modal.md
@@ -27,6 +27,8 @@ The modal component is a core Dyvix UI component. It's a config driven, animated
   - : `string`. Controls the design and the feel of the modal. See the [Themes list](/guide/themes) for a full list.
 - `background`
   - : `string`. Controls the modal background color.
+- `dynamicPositioning`
+  - : `boolean`. Controls whether the modal applies its calculated centering margins. Defaults to `true`; set it to `false` to position the modal with your own styles.
 - `animation`
   - : `string`. Controls the entrance animation of the modal. See the [Animation List](/guide/animations) for a full list.
 - `preset`


### PR DESCRIPTION
Closes #486

## Summary
- document the existing dynamicPositioning Modal prop
- record its boolean type and true default
- explain that disabling it leaves positioning to caller-provided styles

## Validation
- npx prettier --check docs/components/modal/modal.md
- npm run docs:build
- verified the generated Modal documentation contains the new attribute
- git diff --check

The production documentation build completes successfully; its existing dynamic-import and chunk-size warnings remain unchanged.

Developed with OpenAI Codex (GPT-5); I reviewed and validated the final documentation change.